### PR TITLE
Remove deprecated Android package override

### DIFF
--- a/android/src/main/java/com/onradar/react/RNRadarPackage.java
+++ b/android/src/main/java/com/onradar/react/RNRadarPackage.java
@@ -17,7 +17,7 @@ public class RNRadarPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNRadarModule(reactContext));
     }
 
-    @Override
+    //@Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fixed crashed when compile with RN > 0.47+

Related discussion 
https://github.com/react-native-community/react-native-blur/pull/226