### PR TITLE
Make Auth Status on iOS more Descriptive

### DIFF
--- a/ios/RNRadarUtils.m
+++ b/ios/RNRadarUtils.m
@@ -9,9 +9,9 @@
         case kCLAuthorizationStatusRestricted:
             return @"DENIED";
         case kCLAuthorizationStatusAuthorizedAlways:
-            return @"GRANTED";
+            return @"GRANTED_ALWAYS";
         case kCLAuthorizationStatusAuthorizedWhenInUse:
-            return @"GRANTED";
+            return @"GRANTED_WHEN_IN_USE";
         default:
             return @"UNKNOWN";
     }


### PR DESCRIPTION
It's useful in iOS to be able to determine which perms the user granted. Added `_ALWAYS` and `_WHEN_IN_USE` to `GRANTED` statuses.