### PR TITLE
Add alternate places support to events

### DIFF
--- a/android/src/main/java/com/onradar/react/RNRadarUtils.java
+++ b/android/src/main/java/com/onradar/react/RNRadarUtils.java
@@ -276,11 +276,11 @@ class RNRadarUtils {
         return map;
     }
 
-    private static arrayForAlternatePlaces(RadarPlace[] places) {
+    private static WritableArray arrayForAlternatePlaces(RadarPlace[] places) {
         if (places == null) {
             return null;
         }
-    
+
         WritableArray arr = Arguments.createArray();
         for (RadarPlace place : places) {
             WritableMap map = RNRadarUtils.mapForPlace(place);

--- a/android/src/main/java/com/onradar/react/RNRadarUtils.java
+++ b/android/src/main/java/com/onradar/react/RNRadarUtils.java
@@ -269,7 +269,24 @@ class RNRadarUtils {
         if (event.getDuration() != 0) {
             map.putDouble("duration", event.getDuration());
         }
+        WritableArray alternatePlaces = RNRadarUtils.arrayForAlternatePlaces(event.alternatePlaces);
+        if (alternatePlaces != null) {
+            map.putArray("alternatePlaces", alternatePlaces);
+        }
         return map;
+    }
+
+    private static arrayForAlternatePlaces(RadarPlace[] places) {
+        if (places == null) {
+            return null;
+        }
+    
+        WritableArray arr = Arguments.createArray();
+        for (RadarPlace place : places) {
+            WritableMap map = RNRadarUtils.mapForPlace(place);
+            arr.pushMap(map);
+        }
+        return arr;
     }
 
     static WritableMap mapForLocation(Location location) {

--- a/android/src/main/java/com/onradar/react/RNRadarUtils.java
+++ b/android/src/main/java/com/onradar/react/RNRadarUtils.java
@@ -269,7 +269,7 @@ class RNRadarUtils {
         if (event.getDuration() != 0) {
             map.putDouble("duration", event.getDuration());
         }
-        WritableArray alternatePlaces = RNRadarUtils.arrayForAlternatePlaces(event.alternatePlaces);
+        WritableArray alternatePlaces = RNRadarUtils.arrayForAlternatePlaces(event.getAlternatePlaces());
         if (alternatePlaces != null) {
             map.putArray("alternatePlaces", alternatePlaces);
         }

--- a/ios/RNRadarUtils.h
+++ b/ios/RNRadarUtils.h
@@ -16,5 +16,5 @@
 + (NSDictionary *)dictionaryForEvent:(RadarEvent *)event;
 + (NSDictionary *)dictionaryForLocation:(CLLocation *)location;
 + (RadarPlacesProvider)placesProviderForString:(NSString *)providerStr;
-
++ (NSArray *)arrayForAlterantePlaces:(NSArray<RadarPlace *> *)places;
 @end

--- a/ios/RNRadarUtils.h
+++ b/ios/RNRadarUtils.h
@@ -17,4 +17,5 @@
 + (NSDictionary *)dictionaryForLocation:(CLLocation *)location;
 + (RadarPlacesProvider)placesProviderForString:(NSString *)providerStr;
 + (NSArray *)arrayForAlterantePlaces:(NSArray<RadarPlace *> *)places;
+
 @end

--- a/ios/RNRadarUtils.m
+++ b/ios/RNRadarUtils.m
@@ -274,7 +274,24 @@
     if (event.duration) {
         [dict setValue:@(event.duration) forKey:@"duration"];
     }
+    NSArray *alternatePlaces = [RNRadarUtils arrayForAlterantePlaces:event.alternatePlaces];
+    if (alternatePlaces) {
+        [dict setValue:alternatePlaces forKey:@"alternatePlaces"];
+    }
     return dict;
+}
+
++ (NSArray *)arrayForAlterantePlaces:(NSArray<RadarPlace *> *)places {
+    if (!places) {
+        return nil;
+    }
+    
+    NSMutableArray *arr = [[NSMutableArray alloc] initWithCapacity:places.count];
+    for (RadarPlace *place in places) {
+        NSDictionary *dict = [RNRadarUtils dictionaryForPlace:place];
+        [arr addObject:dict];
+    }
+    return arr;
 }
 
 + (NSDictionary *)dictionaryForLocation:(CLLocation *)location {


### PR DESCRIPTION
Seeing that the native modules were returning `event.alternatePlaces` already, it was really straightforward to add methods which add the `alternatePlaces` array to the event being returned to the react-native event emitter. I have tested this for both iOS and Android and seems to work properly. This resolves issue #20. 