### PR TITLE
Fixes a Typo and adds the possibility to manually add the SDK to iOS

### DIFF
--- a/ios/RNRadar.xcodeproj/project.pbxproj
+++ b/ios/RNRadar.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -215,6 +216,8 @@
 					"$(SRCROOT)/../../react-native/React/**",
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
 					"${SRCROOT}/../../../ios/RadarSDK/**",
+					"${SRCROOT}/../../../ios/**",
+					"$(PROJECT_DIR)",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -231,6 +234,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -239,6 +243,8 @@
 					"$(SRCROOT)/../../react-native/React/**",
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
 					"${SRCROOT}/../../../ios/RadarSDK/**",
+					"${SRCROOT}/../../../ios/**",
+					"$(PROJECT_DIR)",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";

--- a/ios/RNRadarUtils.m
+++ b/ios/RNRadarUtils.m
@@ -274,7 +274,7 @@
     if (event.duration) {
         [dict setValue:@(event.duration) forKey:@"duration"];
     }
-    NSArray *alternatePlaces = [RNRadarUtils arrayForAlterantePlaces:event.alternatePlaces];
+    NSArray *alternatePlaces = [RNRadarUtils arrayForAlternatePlaces:event.alternatePlaces];
     if (alternatePlaces) {
         [dict setValue:alternatePlaces forKey:@"alternatePlaces"];
     }


### PR DESCRIPTION
We are not using cocoapods or carthage in our products and I noticed that following the manual installation instructions in radar.io documentation failed with the react-native component.
This PR fixes that allowing for the SDK to be placed inside the `ios` folder.
This also fixes a typo in a method call to `arrayForAlternatePlaces` in `RNRadarUtils`.