### PR TITLE
Issue 18 - [iOS] Return "GRANTED_ALWAYS" when status is Always Allow and  [Android] "DENIED_FOREVER" when user selects 'never ask again' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Radar.getPermissionsStatus().then((status) => {
 - `GRANTED`
 - `GRANTED_ALWAYS` (iOS)
 - `DENIED`
-- `UNKNOWN`
+- `DENIED_FOREVER` (Android, this will be returned if the user seleced the `never ask again` checkbox)
+- `UNKNOWN` (iOS)
 
 To request location permissions for the app, call:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Radar.getPermissionsStatus().then((status) => {
 `status` will be a string, one of:
 
 - `GRANTED`
+- `GRANTED_ALWAYS` (iOS)
 - `DENIED`
 - `UNKNOWN`
 

--- a/android/.classpath
+++ b/android/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/android/.project
+++ b/android/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android</name>
+	<comment>Project android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=
+eclipse.preferences.version=1

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -48,7 +48,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void getPermissionsStatus(Promise promise) {
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
             ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            Activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
+            ActivityCompat.shouldShowRequestPermissionRationale(MainActivity.this, Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -48,7 +48,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void getPermissionsStatus(Promise promise) {
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
             ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            ActivityCompat.shouldShowRequestPermissionRationale(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION)
+            ActivityCompat.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -48,7 +48,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void getPermissionsStatus(Promise promise) {
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
             ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
+            ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -48,7 +48,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void getPermissionsStatus(Promise promise) {
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
             ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            ActivityCompat.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
+            shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -46,9 +46,10 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getPermissionsStatus(Promise promise) {
+        Activity activity = getCurrentActivity();
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
             ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            ActivityCompat.shouldShowRequestPermissionRationale(MainActivity.this, Manifest.permission.ACCESS_FINE_LOCATION)
+            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -47,7 +47,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void getPermissionsStatus(Promise promise) {
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
-            ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+            ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
+            ActivityCompat.shouldShowRequestPermissionRationale(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -48,7 +48,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void getPermissionsStatus(Promise promise) {
         promise.resolve(RNRadarUtils.stringForPermissionsStatus(
             ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_FINE_LOCATION)
+            Activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
         ));
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -47,10 +47,13 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void getPermissionsStatus(Promise promise) {
         Activity activity = getCurrentActivity();
-        promise.resolve(RNRadarUtils.stringForPermissionsStatus(
-            ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
-            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION)
-        ));
+        if (activity != null) {
+            promise.resolve(RNRadarUtils.stringForPermissionsStatus(
+                    ActivityCompat.checkSelfPermission(getReactApplicationContext(),
+                            Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED,
+                    ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                            Manifest.permission.ACCESS_FINE_LOCATION)));
+        }
     }
 
     @ReactMethod
@@ -75,7 +78,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void trackOnce(final Promise promise) {
         Radar.trackOnce(new RadarCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, Location location, RadarEvent[] events, RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, Location location, RadarEvent[] events,
+                    RadarUser user) {
                 if (promise == null)
                     return;
 
@@ -100,14 +104,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     public void updateLocation(ReadableMap locationMap, final Promise promise) {
         double latitude = locationMap.getDouble("latitude");
         double longitude = locationMap.getDouble("longitude");
-        float accuracy = (float)locationMap.getDouble("accuracy");
+        float accuracy = (float) locationMap.getDouble("accuracy");
         Location location = new Location("RNRadarModule");
         location.setLatitude(latitude);
         location.setLongitude(longitude);
         location.setAccuracy(accuracy);
         Radar.updateLocation(location, new RadarCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, Location location, RadarEvent[] events, RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, Location location, RadarEvent[] events,
+                    RadarUser user) {
                 if (promise == null)
                     return;
 

--- a/android/src/main/java/io/radar/react/RNRadarUtils.java
+++ b/android/src/main/java/io/radar/react/RNRadarUtils.java
@@ -19,13 +19,15 @@ import io.radar.sdk.model.RadarUserInsightsState;
 class RNRadarUtils {
 
     static String stringForPermissionsStatus(boolean hasGrantedPermissions, boolean showRationale) {
-        if (hasGrantedPermissions) {
-            return "GRANTED";
-        }
         if (showRationale) {
             return "DENIED";
+        } else {
+            if (hasGrantedPermissions) {
+                return "GRANTED";
+            } else {
+                return "DENIED_FOREVER";
+            }
         }
-        return "DENIED_FOREVER";
     }
 
     static String stringForStatus(Radar.RadarStatus status) {

--- a/android/src/main/java/io/radar/react/RNRadarUtils.java
+++ b/android/src/main/java/io/radar/react/RNRadarUtils.java
@@ -18,11 +18,14 @@ import io.radar.sdk.model.RadarUserInsightsState;
 
 class RNRadarUtils {
 
-    static String stringForPermissionsStatus(boolean hasGrantedPermissions) {
+    static String stringForPermissionsStatus(boolean hasGrantedPermissions, boolean showRationale) {
         if (hasGrantedPermissions) {
             return "GRANTED";
         }
-        return "DENIED";
+        if (showRationale) {
+            return "DENIED";
+        }
+        return "DENIED_FOREVER";
     }
 
     static String stringForStatus(Radar.RadarStatus status) {

--- a/android/src/main/java/io/radar/react/RNRadarUtils.java
+++ b/android/src/main/java/io/radar/react/RNRadarUtils.java
@@ -19,13 +19,13 @@ import io.radar.sdk.model.RadarUserInsightsState;
 class RNRadarUtils {
 
     static String stringForPermissionsStatus(boolean hasGrantedPermissions, boolean showRationale) {
-        if (showRationale) {
-            return "DENIED";
+        if (hasGrantedPermissions) {
+            return "GRANTED";
         } else {
-            if (hasGrantedPermissions) {
-                return "GRANTED";
+            if (!showRationale) {
+                return "DENIED_NOT_RATIONALE";
             } else {
-                return "DENIED_FOREVER";
+                return "DENIED";
             }
         }
     }

--- a/ios/RNRadarUtils.m
+++ b/ios/RNRadarUtils.m
@@ -9,7 +9,7 @@
         case kCLAuthorizationStatusRestricted:
             return @"DENIED";
         case kCLAuthorizationStatusAuthorizedAlways:
-            return @"GRANTED";
+            return @"GRANTED_ALWAYS";
         case kCLAuthorizationStatusAuthorizedWhenInUse:
             return @"GRANTED";
         default:


### PR DESCRIPTION
This was a simple change I'm proposing "GRANTED_ALWAYS" as a string constant when the status is kCLAuthorizationStatusAuthorizedAlways.

I'm guessing it was previously just "GRANTED" to keep consistency between both platforms but since Android doesn't really need it and it doesn't even use UNKNOWN, to begin with I don't think this should