### PR TITLE
Fix dependency declaration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
-    implementation 'io.radar:sdk:2.1.+'
+    api 'com.facebook.react:react-native:+'
+    api 'io.radar:sdk:2.1.+'
 }


### PR DESCRIPTION
Android module is built dynamically so we need to expose transitive deps with `api` rather than `implementation` 