### PR TITLE
Expose the new RadarTrackingOptions from SDK 2.1

### DIFF
--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -14,9 +14,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import io.radar.sdk.Radar;
-import io.radar.sdk.Radar.RadarTrackingOffline;
-import io.radar.sdk.Radar.RadarTrackingSync;
-import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.Radar.RadarCallback;
 import io.radar.sdk.model.RadarEvent;
 import io.radar.sdk.model.RadarUser;
@@ -64,30 +61,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void startTracking(ReadableMap optionsMap) {
-        RadarTrackingOptions.Builder options = new RadarTrackingOptions.Builder();
-        if (optionsMap != null) {
-            if (optionsMap.hasKey("sync")) {
-                switch (optionsMap.getString("sync")) {
-                    case "possibleStateChanges":
-                        options.sync(RadarTrackingSync.POSSIBLE_STATE_CHANGES);
-                        break;
-                    case "all":
-                        options.sync(RadarTrackingSync.ALL);
-                        break;
-                }
-            }
-            if (optionsMap.hasKey("offline")) {
-                switch (optionsMap.getString("offline")) {
-                    case "replayStopped":
-                        options.offline(RadarTrackingOffline.REPLAY_STOPPED);
-                        break;
-                    case "replayOff":
-                        options.offline(RadarTrackingOffline.REPLAY_OFF);
-                        break;
-                }
-            }
-        }
-        Radar.startTracking(options.build());
+        Radar.startTracking(RNRadarUtils.optionsForMap(optionsMap));
     }
 
     @ReactMethod

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -14,6 +14,9 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import io.radar.sdk.Radar;
+import io.radar.sdk.Radar.RadarTrackingOffline;
+import io.radar.sdk.Radar.RadarTrackingSync;
+import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.Radar.RadarCallback;
 import io.radar.sdk.model.RadarEvent;
 import io.radar.sdk.model.RadarUser;
@@ -60,8 +63,31 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void startTracking() {
-        Radar.startTracking();
+    public void startTracking(ReadableMap optionsMap) {
+        RadarTrackingOptions.Builder options = new RadarTrackingOptions.Builder();
+        if (optionsMap != null) {
+            if (optionsMap.hasKey("sync")) {
+                switch (optionsMap.getString("sync")) {
+                    case "possibleStateChanges":
+                        options.sync(RadarTrackingSync.POSSIBLE_STATE_CHANGES);
+                        break;
+                    case "all":
+                        options.sync(RadarTrackingSync.ALL);
+                        break;
+                }
+            }
+            if (optionsMap.hasKey("offline")) {
+                switch (optionsMap.getString("offline")) {
+                    case "replayStopped":
+                        options.offline(RadarTrackingOffline.REPLAY_STOPPED);
+                        break;
+                    case "replayOff":
+                        options.offline(RadarTrackingOffline.REPLAY_OFF);
+                        break;
+                }
+            }
+        }
+        Radar.startTracking(options.build());
     }
 
     @ReactMethod

--- a/android/src/main/java/io/radar/react/RNRadarUtils.java
+++ b/android/src/main/java/io/radar/react/RNRadarUtils.java
@@ -5,12 +5,16 @@ import java.util.Iterator;
 import org.json.JSONObject;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import io.radar.sdk.Radar;
+import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.model.RadarEvent;
 import io.radar.sdk.model.RadarGeofence;
 import io.radar.sdk.model.RadarPlace;
+import io.radar.sdk.Radar.RadarTrackingOffline;
+import io.radar.sdk.Radar.RadarTrackingSync;
 import io.radar.sdk.model.RadarUser;
 import io.radar.sdk.model.RadarUserInsights;
 import io.radar.sdk.model.RadarUserInsightsLocation;
@@ -330,6 +334,33 @@ class RNRadarUtils {
             map.putDouble("accuracy", location.getAccuracy());
         }
         return map;
+    }
+
+    static RadarTrackingOptions optionsForMap(ReadableMap optionsMap) {
+        RadarTrackingOptions.Builder options = new RadarTrackingOptions.Builder();
+        if (optionsMap != null) {
+            if (optionsMap.hasKey("sync")) {
+                switch (optionsMap.getString("sync")) {
+                    case "possibleStateChanges":
+                        options.sync(RadarTrackingSync.POSSIBLE_STATE_CHANGES);
+                        break;
+                    case "all":
+                        options.sync(RadarTrackingSync.ALL);
+                        break;
+                }
+            }
+            if (optionsMap.hasKey("offline")) {
+                switch (optionsMap.getString("offline")) {
+                    case "replayStopped":
+                        options.offline(RadarTrackingOffline.REPLAY_STOPPED);
+                        break;
+                    case "replayOff":
+                        options.offline(RadarTrackingOffline.REPLAY_OFF);
+                        break;
+                }
+            }
+        }
+        return options.build();
     }
 
 }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -80,8 +80,28 @@ RCT_EXPORT_METHOD(requestPermissions:(BOOL)background) {
     }
 }
 
-RCT_EXPORT_METHOD(startTracking) {
-    [Radar startTracking];
+RCT_EXPORT_METHOD(startTracking:(NSDictionary *)optionsDict) {
+    RadarTrackingOptions *options = [RadarTrackingOptions new];
+    if (optionsDict) {
+        if (optionsDict[@"sync"]) {
+            NSString *sync = [RCTConvert NSString:optionsDict[@"sync"]];
+            if ([sync isEqualToString:@"possibleStateChanges"]) {
+                options.sync = RadarTrackingSyncPossibleStateChanges;
+            } else if ([sync isEqualToString:@"all"]) {
+                options.sync = RadarTrackingSyncAll;
+            }
+        }
+        if (optionsDict[@"offline"]) {
+            NSString *offline = [RCTConvert NSString:optionsDict[@"offline"]];
+            if ([offline isEqualToString:@"replayStopped"]) {
+                options.offline = RadarTrackingOfflineReplayStopped;
+            } else if ([offline isEqualToString:@"replayOff"]) {
+                options.offline = RadarTrackingOfflineReplayOff;
+            }
+        }
+    }
+    [RCTConvert NSString:optionsDict[@"location"]];
+    [Radar startTrackingWithOptions:options];
 }
 
 RCT_EXPORT_METHOD(stopTracking) {

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -81,27 +81,7 @@ RCT_EXPORT_METHOD(requestPermissions:(BOOL)background) {
 }
 
 RCT_EXPORT_METHOD(startTracking:(NSDictionary *)optionsDict) {
-    RadarTrackingOptions *options = [RadarTrackingOptions new];
-    if (optionsDict) {
-        if (optionsDict[@"sync"]) {
-            NSString *sync = [RCTConvert NSString:optionsDict[@"sync"]];
-            if ([sync isEqualToString:@"possibleStateChanges"]) {
-                options.sync = RadarTrackingSyncPossibleStateChanges;
-            } else if ([sync isEqualToString:@"all"]) {
-                options.sync = RadarTrackingSyncAll;
-            }
-        }
-        if (optionsDict[@"offline"]) {
-            NSString *offline = [RCTConvert NSString:optionsDict[@"offline"]];
-            if ([offline isEqualToString:@"replayStopped"]) {
-                options.offline = RadarTrackingOfflineReplayStopped;
-            } else if ([offline isEqualToString:@"replayOff"]) {
-                options.offline = RadarTrackingOfflineReplayOff;
-            }
-        }
-    }
-    [RCTConvert NSString:optionsDict[@"location"]];
-    [Radar startTrackingWithOptions:options];
+    [Radar startTrackingWithOptions:[RNRadarUtils optionsForDictionary:optionsDict]];
 }
 
 RCT_EXPORT_METHOD(stopTracking) {

--- a/ios/RNRadarUtils.h
+++ b/ios/RNRadarUtils.h
@@ -17,5 +17,6 @@
 + (NSDictionary *)dictionaryForLocation:(CLLocation *)location;
 + (RadarPlacesProvider)placesProviderForString:(NSString *)providerStr;
 + (NSArray *)arrayForAlternatePlaces:(NSArray<RadarPlace *> *)places;
++ (RadarTrackingOptions *)optionsForDictionary:(NSDictionary *)optionsDict;
 
 @end

--- a/ios/RNRadarUtils.m
+++ b/ios/RNRadarUtils.m
@@ -1,4 +1,5 @@
 #import "RNRadarUtils.h"
+#import <React/RCTConvert.h>
 
 @implementation RNRadarUtils
 
@@ -311,5 +312,29 @@
     }
     return dict;
 }
+
++ (RadarTrackingOptions *)optionsForDictionary:(NSDictionary *)optionsDict {
+    RadarTrackingOptions *options = [RadarTrackingOptions new];
+    if (optionsDict) {
+        if (optionsDict[@"sync"]) {
+            NSString *sync = [RCTConvert NSString:optionsDict[@"sync"]];
+            if ([sync isEqualToString:@"possibleStateChanges"]) {
+                options.sync = RadarTrackingSyncPossibleStateChanges;
+            } else if ([sync isEqualToString:@"all"]) {
+                options.sync = RadarTrackingSyncAll;
+            }
+        }
+        if (optionsDict[@"offline"]) {
+            NSString *offline = [RCTConvert NSString:optionsDict[@"offline"]];
+            if ([offline isEqualToString:@"replayStopped"]) {
+                options.offline = RadarTrackingOfflineReplayStopped;
+            } else if ([offline isEqualToString:@"replayOff"]) {
+                options.offline = RadarTrackingOfflineReplayOff;
+            }
+        }
+    }
+    return options;
+}
+
 
 @end

--- a/js/index.js
+++ b/js/index.js
@@ -26,9 +26,9 @@ const requestPermissions = (background) => {
   NativeModules.RNRadar.requestPermissions(background);
 };
 
-const startTracking = () => {
-  NativeModules.RNRadar.startTracking();
-};
+const startTracking = (options) => {
+  NativeModules.RNRadar.startTracking(options);
+}
 
 const stopTracking = () => {
   NativeModules.RNRadar.stopTracking();

--- a/js/index.js
+++ b/js/index.js
@@ -28,7 +28,7 @@ const requestPermissions = (background) => {
 
 const startTracking = (options) => {
   NativeModules.RNRadar.startTracking(options);
-}
+};
 
 const stopTracking = () => {
   NativeModules.RNRadar.stopTracking();


### PR DESCRIPTION
This allows users to apply the new options like so:
```js
Radar.startTracking({
  sync: 'all', // or 'possibleStateChanges'
  offline: 'replayStopped' // or 'replayOff'
})
```