### PR TITLE
Add `requiresMainQueueSetup` to RNRadar

### DIFF
--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -143,4 +143,9 @@ RCT_EXPORT_METHOD(rejectEvent:(NSString *)eventId) {
     [Radar rejectEventId:eventId];
 }
 
++(BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Fix warning in iOS:
>Module RNRadar requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.