### PR TITLE
Added cocoapods podspec

### DIFF
--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -26,6 +26,12 @@ RCT_EXPORT_MODULE();
     return YES;
 }
 
+- (dispatch_queue_t)methodQueue
+{
+    // fix for UI API called on a background thread
+    return dispatch_get_main_queue();
+}
+
 - (NSArray<NSString *> *)supportedEvents {
     return @[@"events", @"location", @"error"];
 }

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -1,0 +1,19 @@
+require "json"
+
+json = File.read(File.join(__dir__, "package.json"))
+package = JSON.parse(json).deep_symbolize_keys
+
+Pod::Spec.new do |s|
+  s.name = package[:name]
+  s.version = package[:version]
+  s.license = { type: "MIT" }
+  s.homepage = "https://github.com/radarlabs/react-native-radar"
+  s.authors = package[:author] || "radarlabs"
+  s.summary = package[:description]
+  s.source = { git: package[:repository][:url] }
+  s.source_files = "ios/**/*.{h,m}"
+  s.platform = :ios, "9.0"
+
+  s.dependency "React"
+  s.dependency "RadarSDK"
+end


### PR DESCRIPTION
Some React Native apps are actively use Cocoapods for manning internal dependancies than linking libraries in old way breaks build system.  

Here is an example of Podsfile of such an app, it is more or less standard:
```
# Uncomment the next line to define a global platform for your project
platform :ios, '9.0'
workspace '.ignored/workspace' # trick to avoid opening workspace (Pods is added as subproject)
inhibit_all_warnings! # ignore all warnings from pods

target 'App' do
  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
  # use_frameworks!

  # Native Dependancies for App
  pod 'Fabric', '1.9.0'
  pod 'Crashlytics', '3.12.0'

  # Huge Beast and Heart of the project
  pod 'React', :path => '../node_modules/react-native', :subspecs => [
    'Core',
    'CxxBridge', # Include this for RN >= 0.47
    'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
    'RCTText',
    'RCTNetwork',
    'RCTWebSocket', # Needed for debugging
    'RCTAnimation', # Needed for FlatList and animations running on native UI thread
    'RCTGeolocation',
    'RCTBlob',
    'RCTImage',
    'RCTLinkingIOS',
    'RCTSettings',
    'RCTActionSheet',
    # Add any other subspecs you want to use in your project
  ]
  # Explicitly include Yoga if you are using RN >= 0.42.0
  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'

  # React Native Built-in third party dependancies podspec link
  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'

  # React Native Linked Dependancies:
  pod 'react-native-radar', :path => '../node_modules/react-native-radar'

end
```

If podspec file is present in the repo `react-native link` will update Podfile by adding such a line in the end

