### PR TITLE
Release 2.1.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
   android:
     working_directory: ~/react-native-radar
     docker:
-      - image: circleci/android:api-28-node8-alpha
+      - image: circleci/android:api-28-node
     steps:
       - checkout:
 

--- a/ios/.npmignore
+++ b/ios/.npmignore
@@ -1,3 +1,0 @@
-Cartfile*
-Carthage/
-RNRadarTests/

--- a/ios/RNRadar.xcodeproj/project.pbxproj
+++ b/ios/RNRadar.xcodeproj/project.pbxproj
@@ -320,7 +320,6 @@
 				TargetAttributes = {
 					466EF48921DFC28700ED0E09 = {
 						CreatedOnToolsVersion = 10.1;
-						DevelopmentTeam = 96GHH65B9D;
 						ProvisioningStyle = Automatic;
 					};
 					58B511DA1A9E6C8500147676 = {
@@ -535,7 +534,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 96GHH65B9D;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -588,7 +587,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 96GHH65B9D;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "main": "js/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "description": "React Native module for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "main": "js/index.js",
   "files": [
     "android",
     "ios",
     "js",
-    "README.md"
+    "README.md",
+    "react-native-radar.podspec"
   ],
   "scripts": {
     "testJs": "jest ./test/*.test.js",

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -1,0 +1,19 @@
+require "json"
+
+json = File.read(File.join(__dir__, "package.json"))
+package = JSON.parse(json).deep_symbolize_keys
+
+Pod::Spec.new do |s|
+  s.name = package[:name]
+  s.version = package[:version]
+  s.license = { type: "Apache-2.0" }
+  s.homepage = "https://github.com/radarlabs/react-native-radar"
+  s.authors = package[:author] || "radarlabs"
+  s.summary = package[:description]
+  s.source = { git: package[:repository][:url] }
+  s.source_files = "ios/**/*.{h,m}"
+  s.platform = :ios, "9.0"
+
+  s.dependency "React"
+  s.dependency "RadarSDK"
+end


### PR DESCRIPTION
- Removes `.npmignore` for `ios` directory, therefore adding tests to npm package