### PR TITLE
Release 2.1.7

### DIFF
--- a/ios/RNRadar.xcodeproj/project.pbxproj
+++ b/ios/RNRadar.xcodeproj/project.pbxproj
@@ -705,6 +705,7 @@
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
 					"${SRCROOT}/../../../ios/RadarSDK/**",
 					"$(SRCROOT)/Carthage/Build/iOS/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -733,6 +734,7 @@
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
 					"${SRCROOT}/../../../ios/RadarSDK/**",
 					"$(SRCROOT)/Carthage/Build/iOS/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";

--- a/ios/RNRadar.xcodeproj/project.pbxproj
+++ b/ios/RNRadar.xcodeproj/project.pbxproj
@@ -694,6 +694,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"${SRCROOT}/../../../ios/**",
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
@@ -723,6 +724,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"${SRCROOT}/../../../ios/**",
 					"${SRCROOT}/../../../ios/Pods/RadarSDK/**",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "main": "js/index.js",
   "files": [
     "android",


### PR DESCRIPTION
Addresses #69 : 
- Adds default `ios/` directory to framework and header search paths, so the native module can find the linked `RadarSDK.framework`