### PR TITLE
Api updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: jest tests
           command: |
             mkdir -p test-results/jest
-            npm run testJs
+            npm run test-js
           environment:
             JEST_JUNIT_OUTPUT: test-results/jest/junit.xml
 
@@ -48,7 +48,7 @@ jobs:
       - attach_workspace:
           at: ~/react-native-radar
       
-      - run: npm run testAndroid
+      - run: npm run test-android
 
       - run:
           name: Save test results
@@ -104,7 +104,7 @@ jobs:
           name: Run iOS tests
           command: |
             mkdir -p test-results/ios
-            npm run testIOS | xcpretty -r junit --output test-results/ios/junit.xml
+            npm run test-ios | xcpretty -r junit --output test-results/ios/junit.xml
 
       - store_test_results:
           path: test-results

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     api 'io.radar:sdk:2.1.+'
 
     testImplementation 'org.mockito:mockito-core:2.23.4'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'
+    testImplementation 'org.json:json:20180813'
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -17,6 +17,7 @@ import io.radar.sdk.Radar;
 import io.radar.sdk.Radar.RadarCallback;
 import io.radar.sdk.model.RadarEvent;
 import io.radar.sdk.model.RadarUser;
+import org.json.JSONException;
 
 public class RNRadarModule extends ReactContextBaseJavaModule {
 
@@ -37,6 +38,11 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setDescription(String description) {
         Radar.setDescription(description);
+    }
+
+    @ReactMethod
+    public void setMetadata(ReadableMap metadataMap) throws JSONException {
+        Radar.setMetadata(RNRadarUtils.jsonObjectForMap(metadataMap));
     }
 
     @ReactMethod

--- a/android/src/main/java/io/radar/react/RNRadarUtils.java
+++ b/android/src/main/java/io/radar/react/RNRadarUtils.java
@@ -1,6 +1,7 @@
 package io.radar.react;
 
 import android.location.Location;
+import io.radar.sdk.Radar.RadarTrackingPriority;
 import java.util.Iterator;
 import org.json.JSONObject;
 
@@ -356,6 +357,16 @@ class RNRadarUtils {
                         break;
                     case "replayOff":
                         options.offline(RadarTrackingOffline.REPLAY_OFF);
+                        break;
+                }
+            }
+            if (optionsMap.hasKey("priority")) {
+                switch (optionsMap.getString("priority")) {
+                    case "efficiency":
+                        options.priority(RadarTrackingPriority.EFFICIENCY);
+                        break;
+                    case "responsiveness":
+                        options.priority(RadarTrackingPriority.RESPONSIVENESS);
                         break;
                 }
             }

--- a/android/src/main/java/io/radar/react/RNRadarUtils.java
+++ b/android/src/main/java/io/radar/react/RNRadarUtils.java
@@ -1,8 +1,11 @@
 package io.radar.react;
 
 import android.location.Location;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
 import io.radar.sdk.Radar.RadarTrackingPriority;
 import java.util.Iterator;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.facebook.react.bridge.Arguments;
@@ -105,6 +108,27 @@ class RNRadarUtils {
             return Radar.RadarPlacesProvider.FACEBOOK;
         }
         return Radar.RadarPlacesProvider.NONE;
+    }
+
+    static JSONObject jsonObjectForMap(ReadableMap map) throws JSONException {
+        JSONObject obj = new JSONObject();
+        ReadableMapKeySetIterator keys = map.keySetIterator();
+        while (keys.hasNextKey()) {
+            String key = keys.nextKey();
+            ReadableType type = map.getType(key);
+            switch (type) {
+                case Number:
+                    obj.put(key, map.getDouble(key));
+                    break;
+                case String:
+                    obj.put(key, map.getString(key));
+                    break;
+                case Boolean:
+                    obj.put(key, map.getBoolean(key));
+                    break;
+            }
+        }
+        return obj;
     }
 
     private static WritableMap mapForJSONObject(JSONObject obj) {

--- a/android/src/test/java/io/radar/react/RNRadarModuleTest.java
+++ b/android/src/test/java/io/radar/react/RNRadarModuleTest.java
@@ -23,6 +23,8 @@ import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.model.RadarEvent;
 import io.radar.sdk.model.RadarGeofence;
 import io.radar.sdk.model.RadarUser;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -101,6 +103,19 @@ public class RNRadarModuleTest {
 
     verifyStatic(Radar.class);
     Radar.setDescription(description);
+  }
+
+  @Test
+  public void setMetadata() throws JSONException {
+    ReadableMap metadataMap = new JavaOnlyMap();
+    JSONObject metadata = new JSONObject("{test:123}");
+    when(RNRadarUtils.jsonObjectForMap(metadataMap)).thenReturn(metadata);
+
+    System.err.println(metadata.toString());
+    module.setMetadata(metadataMap);
+
+    verifyStatic(Radar.class);
+    Radar.setMetadata(metadata);
   }
 
   @Test

--- a/android/src/test/java/io/radar/react/RNRadarUtilsTest.java
+++ b/android/src/test/java/io/radar/react/RNRadarUtilsTest.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.WritableMap;
 import io.radar.sdk.Radar.RadarPlacesProvider;
 import io.radar.sdk.Radar.RadarStatus;
 import io.radar.sdk.Radar.RadarTrackingOffline;
+import io.radar.sdk.Radar.RadarTrackingPriority;
 import io.radar.sdk.Radar.RadarTrackingSync;
 import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.model.RadarEvent;
@@ -204,11 +205,25 @@ public class RNRadarUtilsTest {
     WritableMap optionsMap = new JavaOnlyMap();
     optionsMap.putString("sync", "all");
     optionsMap.putString("offline", "replayOff");
+    optionsMap.putString("priority", "efficiency");
     optionsMap.putString("invalid", "shouldBeIgnored");
 
     RadarTrackingOptions options = RNRadarUtils.optionsForMap(optionsMap);
 
     assertEquals(RadarTrackingSync.ALL, options.getSync());
     assertEquals(RadarTrackingOffline.REPLAY_OFF, options.getOffline());
+    assertEquals(RadarTrackingPriority.EFFICIENCY, options.getPriority());
+  }
+
+  @Test
+  public void defaultOptionsForMap() {
+    WritableMap optionsMap = new JavaOnlyMap();
+    optionsMap.putString("invalid", "shouldBeIgnored");
+
+    RadarTrackingOptions options = RNRadarUtils.optionsForMap(optionsMap);
+
+    assertEquals(RadarTrackingSync.POSSIBLE_STATE_CHANGES, options.getSync());
+    assertEquals(RadarTrackingOffline.REPLAY_STOPPED, options.getOffline());
+    assertEquals(RadarTrackingPriority.RESPONSIVENESS, options.getPriority());
   }
 }

--- a/android/src/test/java/io/radar/react/RNRadarUtilsTest.java
+++ b/android/src/test/java/io/radar/react/RNRadarUtilsTest.java
@@ -23,6 +23,8 @@ import io.radar.sdk.model.RadarUser;
 import io.radar.sdk.model.RadarUserInsightsLocation.RadarUserInsightsLocationConfidence;
 import io.radar.sdk.model.RadarUserInsightsLocation.RadarUserInsightsLocationType;
 import java.util.Date;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,8 +35,10 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -225,5 +229,23 @@ public class RNRadarUtilsTest {
     assertEquals(RadarTrackingSync.POSSIBLE_STATE_CHANGES, options.getSync());
     assertEquals(RadarTrackingOffline.REPLAY_STOPPED, options.getOffline());
     assertEquals(RadarTrackingPriority.RESPONSIVENESS, options.getPriority());
+  }
+
+  @Test
+  public void jsonObjectForMap() throws JSONException {
+    WritableMap optionsMap = new JavaOnlyMap();
+    optionsMap.putString("stringKey", "some string");
+    optionsMap.putInt("intKey", 123);
+    optionsMap.putDouble("doubleKey", 1.23);
+    optionsMap.putBoolean("boolKey", true);
+    optionsMap.putMap("otherTypeKey", new JavaOnlyMap());
+
+    JSONObject obj = RNRadarUtils.jsonObjectForMap(optionsMap);
+
+    assertEquals("some string", obj.getString("stringKey"));
+    assertEquals(123, obj.getInt("intKey"));
+    assertEquals(1.23, obj.getDouble("doubleKey"), 0.01);
+    assertTrue(obj.getBoolean("boolKey"));
+    assertFalse(obj.has("otherTypeKey"));
   }
 }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -68,6 +68,10 @@ RCT_EXPORT_METHOD(setDescription:(NSString *)description) {
     [Radar setDescription:description];
 }
 
+RCT_EXPORT_METHOD(setMetadata:(NSDictionary *)metadataDict) {
+    [Radar setMetadata:metadataDict];
+}
+
 RCT_EXPORT_METHOD(setPlacesProvider:(NSString *)providerStr) {
     [Radar setPlacesProvider:[RNRadarUtils placesProviderForString:providerStr]];
 }

--- a/ios/RNRadarTests/RNRadarTests.m
+++ b/ios/RNRadarTests/RNRadarTests.m
@@ -59,6 +59,21 @@
     OCMVerify([radar setDescription:description]);
 }
 
+- (void)testSetMetadata {
+    OCMStub([radar setMetadata:[OCMArg any]]).andDo(nil);
+    
+    NSDictionary *metadata = @{
+                               @"stringKey":@"some string",
+                               @"intKey": @(123),
+                               @"doubleKey": @1.23,
+                               @"boolKey": @YES,
+                               @"unsupportedKey": @{}
+                               };
+    [module setMetadata:metadata];
+    
+    OCMVerify([radar setMetadata:metadata]);
+}
+
 - (void)testSetPlacesProvider {
     NSString *providerStr = @"facebook";
     RadarPlacesProvider provider = RadarPlacesProviderFacebook;

--- a/js/index.js
+++ b/js/index.js
@@ -14,6 +14,10 @@ const setDescription = (description) => {
   NativeModules.RNRadar.setDescription(description);
 };
 
+const setMetadata = (metadata) => {
+  NativeModules.RNRadar.setMetadata(metadata);
+};
+
 const setPlacesProvider = (provider) => {
   NativeModules.RNRadar.setPlacesProvider(provider);
 };
@@ -65,6 +69,7 @@ const off = (event, callback) => {
 const Radar = {
   setUserId,
   setDescription,
+  setMetadata,
   setPlacesProvider,
   getPermissionsStatus,
   requestPermissions,

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "react-native-radar.podspec"
   ],
   "scripts": {
-    "testJs": "jest ./test/*.test.js",
-    "testAndroid": "./android/gradlew test -p android",
-    "testIOS": "xcodebuild test -project ios/RNRadar.xcodeproj -scheme RNRadarTests -destination 'platform=iOS Simulator,name=iPhone 8'",
-    "testAll": "run-p testJs testAndroid testIOS"
+    "test-js": "jest ./test/*.test.js",
+    "test-android": "./android/gradlew test -p android",
+    "test-ios": "xcodebuild test -project ios/RNRadar.xcodeproj -scheme RNRadarTests -destination 'platform=iOS Simulator,name=iPhone 8'",
+    "test-all": "run-p test-js test-android test-ios"
   },
   "jest": {
     "preset": "react-native",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,7 @@ jest.mock('NativeModules', () => (
     RNRadar: {
       setUserId: jest.fn(),
       setDescription: jest.fn(),
+      setMetadata: jest.fn(),
       setPlacesProvider: jest.fn(),
       getPermissionsStatus: jest.fn(),
       requestPermissions: jest.fn(),
@@ -43,6 +44,19 @@ describe('Calls native implementation', () => {
     expect(mockNative.setDescription).toHaveBeenCalledTimes(1);
     expect(mockNative.setDescription).toBeCalledWith(description);
   });
+
+  test('setMetadata', () => {
+    const metadata = {
+      'key': 'some string',
+      'bool': true,
+      'int': 123,
+      'double': 1.23
+    }
+    Radar.setMetadata(metadata)
+
+    expect(mockNative.setMetadata).toHaveBeenCalledTimes(1)
+    expect(mockNative.setMetadata).toBeCalledWith(metadata)
+  })
 
   test('setPlacesProvider', () => {
     const provider = 'facebook';


### PR DESCRIPTION
- Added api for [`setMetadata()`](https://radarlabs.github.io/radar-sdk-ios/Classes/Radar.html#/c:objc(cs)Radar(cm)setMetadata:)
- Added `priority` option for `startTracking()` that corresponds to Android [`RadarTrackingPriority`](https://radarlabs.github.io/radar-sdk-android/io/radar/sdk/Radar.RadarTrackingPriority.html), has no effect on iOS. 
  - accepted values are `efficiency` and `responsiveness` 