### PR TITLE
cve logkitty 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,7 +1219,7 @@
         "chalk": "^2.4.2",
         "execa": "^1.0.0",
         "jetifier": "^1.6.2",
-        "logkitty": "^0.6.0",
+        "logkitty": "^0.7.1",
         "slash": "^3.0.0",
         "xmldoc": "^1.1.2"
       },
@@ -7884,7 +7884,7 @@
       }
     },
     "logkitty": {
-      "version": "0.6.1",
+      "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.6.1.tgz",
       "integrity": "sha512-cHuXN8qUZuzX/7kB6VyS7kB4xyD24e8gyHXIFNhIv+fjW3P+jEXNUhj0o/7qWJtv7UZpbnPgUqzu/AZQ8RAqxQ==",
       "dev": true,


### PR DESCRIPTION
- not 100% on if we also need to update this:
- https://github.com/radarlabs/react-native-radar/blob/master/example/yarn.lock#L876