### PR TITLE
Expose set log level

### DIFF
--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import io.radar.sdk.Radar;
+import io.radar.sdk.Radar.RadarLogLevel
 import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.RadarTripOptions;
 import io.radar.sdk.model.RadarAddress;

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -770,4 +770,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void setLogLevel(int level) {
+      Radar.setLogLevel(level);
+    }
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -770,8 +770,4 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
         }
     }
 
-    @ReactMethod
-    public void setLogLevel(int level) {
-      Radar.setLogLevel(level);
-    }
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -19,7 +19,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import io.radar.sdk.Radar;
-import io.radar.sdk.Radar.RadarLogLevel
+import io.radar.sdk.Radar.RadarLogLevel;
 import io.radar.sdk.RadarTrackingOptions;
 import io.radar.sdk.RadarTripOptions;
 import io.radar.sdk.model.RadarAddress;

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -65,7 +65,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setLogLevel(int level) {
-      Radar.setLogLevel(level);
+      Radar.setLogLevel(Radar.RadarLogLevel.fromInt(level));
     }
 
     @ReactMethod

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -64,6 +64,11 @@ public class RNRadarModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setLogLevel(int level) {
+      Radar.setLogLevel(level);
+    }
+
+    @ReactMethod
     public void getPermissionsStatus(Promise promise) {
         if (promise == null) {
             return;

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -81,7 +81,7 @@ RCT_EXPORT_MODULE();
     }
 }
 
-- (void)setLogLevel:(NSInteger *)level {
+RCT_EXPORT_METHOD(setLogLevel:(NSInteger *)level) {
     [Radar setLogLevel:level];
 }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -81,6 +81,10 @@ RCT_EXPORT_MODULE();
     }
 }
 
+- (void)setLogLevel:(NSInteger *)level {
+    [Radar setLogLevel:level];
+}
+
 RCT_EXPORT_METHOD(setUserId:(NSString *)userId) {
     [Radar setUserId:userId];
 }

--- a/js/index.js
+++ b/js/index.js
@@ -110,6 +110,10 @@ const getDistance = options => (
   NativeModules.RNRadar.getDistance(options)
 );
 
+const setLogLevel = level => (
+  NativeModules.RNRadar.setLogLevel(level)
+);
+
 const on = (event, callback) => (
   eventEmitter.addListener(event, callback)
 );
@@ -151,6 +155,7 @@ const Radar = {
   getDistance,
   on,
   off,
+  setLogLevel,
 };
 
 export default Radar;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, location data infrastructure",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.0.6",
+  "version": "radarlabs/react-native-radar#expose-log-level",
   "main": "js/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, location data infrastructure",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "radarlabs/react-native-radar#expose-log-level",
+  "version": "3.0.7-beta.1",
   "main": "js/index.js",
   "files": [
     "android",


### PR DESCRIPTION
iOS and Android SDK's support setting the SDK log level: https://radarlabs.github.io/radar-sdk-ios/Classes/Radar.html#/c:objc(cs)Radar(cm)setLogLevel:

This exposes that hook in React Native via `Radar.setLogLevel`