### PR TITLE
github action to create react-native-radar SDK releases

### DIFF
--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -1,7 +1,7 @@
 name: Publish Package to npmjs
 on:
   release:
-    types: [created]
+    types: [ published ]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As documented here: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry