### PR TITLE
[9522] Add workflow to automate SDK version bumps

### DIFF
--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -3,11 +3,11 @@
 name: Bump Native SDKs
 on:
   repository_dispatch:
-    types: [ios-sdk-release, android-sdk-release]
+    types: ['ios-sdk-release', 'android-sdk-release']
 jobs:
   update_android_sdk_version:
     runs-on: ubuntu-latest
-    if: github.event.event_type == android-sdk-release
+    if: github.event.event-type == 'android-sdk-release'
     steps:
       - name: Event Information
         run: echo ${{ github.event.client_payload.release }}
@@ -38,7 +38,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   update_ios_sdk_version:
     runs-on: ubuntu-latest
-    if: github.event.event_type == ios-sdk-release
+    if: github.event.event-type == 'ios-sdk-release'
     steps:
       - name: Event Information
         run: echo ${{ github.event.client_payload.release }}

--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -29,6 +29,10 @@ jobs:
           data: version=${{ github.event.client_payload.release }}
           path: "android/build.gradle"
 
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
+
       # open a pull request with the new sdk version
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -73,6 +77,10 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: "ios/Cartfile.resolved"
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
 
       # open a pull request with the new sdk version
       - name: Create Pull Request

--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -1,4 +1,6 @@
-name: Publish Package to npmjs
+# Bump Native SDK version numbers whenever a repository dispatch of a release
+# is received
+name: Bump Native SDKs
 on:
   repository_dispatch:
     types: [ios-sdk-release, android-sdk-release]

--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update_android_sdk_version:
     runs-on: ubuntu-latest
-    if: github.event.event-type == 'android-sdk-release'
+    if: github.event.client_payload.platform == "android"
     steps:
       - name: Event Information
         run: echo ${{ github.event.client_payload.release }}
@@ -38,7 +38,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   update_ios_sdk_version:
     runs-on: ubuntu-latest
-    if: github.event.event-type == 'ios-sdk-release'
+    if: github.event.client_payload.platform == 'iOS'
     steps:
       - name: Event Information
         run: echo ${{ github.event.client_payload.release }}

--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   update_ios_sdk_version:
     runs-on: ubuntu-latest
-    if: github.event.client_payload.platform == 'iOS'
+    if: github.event.client_payload.platform == 'ios'
     steps:
       - name: Event Information
         run: echo ${{ github.event.client_payload.release }}

--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -1,0 +1,81 @@
+name: Publish Package to npmjs
+on:
+  repository_dispatch:
+    types: [ios-sdk-release, android-sdk-release]
+jobs:
+  update_android_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.event_type == android-sdk-release
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the template file to its final destination
+      - name: Copy android/build.gradle template file
+        uses: canastro/copy-action@master
+        with:
+          source: "android/build.gradle.template"
+          target: "android/build.gradle"
+
+      # render the template using the input sdk version
+      - name: Render radar-sdk-android release version onto build.gradle
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "android/build.gradle"
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-android version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}
+  update_ios_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.event_type == ios-sdk-release
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the podspec template to its final destination
+      - name: Copy the podspec template
+        uses: canastro/copy-action@master
+        with:
+          source: "react-native-radar.podspec.template"
+          target: "react-native-radar.podspec"
+
+      # render the podspec template with the sdk version
+      - name: Render radar-sdk-ios release version onto podspec template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "react-native-radar.podspec"
+
+      # copy the Cartfile template to its final destination
+      - name: Copy ios/Cartfile.resolved template
+        uses: canastro/copy-action@master
+        with:
+          source: "ios/Cartfile.resolved.template"
+          target: "ios/Cartfile.resolved"
+
+      # render the Cartfile template with the sdk version
+      - name: Render radar-sdk-ios release version onto Cartfile template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "ios/Cartfile.resolved"
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-ios version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/android/build.gradle.template
+++ b/android/build.gradle.template
@@ -1,0 +1,49 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.0.3'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 31
+        versionCode 1
+        versionName '{{ version }}'
+    }
+    lintOptions {
+        abortOnError false
+    }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+    configurations.all {
+        resolutionStrategy {
+            force 'androidx.core:core:1.6.0'
+            force 'androidx.core:core-ktx:1.6.0'
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+    google()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
+    }
+}
+
+dependencies {
+    api 'com.facebook.react:react-native:+'
+    api 'io.radar:sdk:{{ version }}'
+}

--- a/ios/Cartfile.resolved.template
+++ b/ios/Cartfile.resolved.template
@@ -1,0 +1,1 @@
+github "radarlabs/radar-sdk-ios" "{{ version }}"

--- a/react-native-radar.podspec.template
+++ b/react-native-radar.podspec.template
@@ -1,0 +1,19 @@
+require "json"
+
+json = File.read(File.join(__dir__, "package.json"))
+package = JSON.parse(json).deep_symbolize_keys
+
+Pod::Spec.new do |s|
+  s.name = package[:name]
+  s.version = package[:version]
+  s.license = { type: "Apache-2.0" }
+  s.homepage = "https://github.com/radarlabs/react-native-radar"
+  s.authors = package[:author] || "radarlabs"
+  s.summary = package[:description]
+  s.source = { git: package[:repository][:url] }
+  s.source_files = "ios/*.{h,m}"
+  s.platform = :ios, "10.0"
+
+  s.dependency "React"
+  s.dependency "RadarSDK", "~> {{ version }}"
+end


### PR DESCRIPTION
## Summary
Add Github Action that automates:
- updating `build.gradle` for Android SDK version bumps
- updating `Cartfile.resolved` + `react-native-radar.podspec` for iOS SDK version bumps
- updating `package.json` and `package-lock.json`