### PR TITLE
[Automation] Triage Version-bump Github Action

### DIFF
--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -15,10 +15,6 @@ jobs:
       # checkout the repo
       - uses: actions/checkout@v2
 
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
-
       # copy the template file to its final destination
       - name: Copy android/build.gradle template file
         uses: canastro/copy-action@master
@@ -32,6 +28,10 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: 'android/build.gradle'
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }} --commit-hooks false --git-tag-version false
 
       # open a pull request with the new sdk version
       - name: Create Pull Request
@@ -49,10 +49,6 @@ jobs:
 
       # checkout the repo
       - uses: actions/checkout@v2
-
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
 
       # copy the podspec template to its final destination
       - name: Copy the podspec template
@@ -81,6 +77,10 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: 'ios/Cartfile.resolved'
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }} --commit-hooks false --git-tag-version false
 
       # open a pull request with the new sdk version
       - name: Create Pull Request

--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -15,6 +15,10 @@ jobs:
       # checkout the repo
       - uses: actions/checkout@v2
 
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
+
       # copy the template file to its final destination
       - name: Copy android/build.gradle template file
         uses: canastro/copy-action@master
@@ -28,10 +32,6 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: 'android/build.gradle'
-
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
 
       # open a pull request with the new sdk version
       - name: Create Pull Request
@@ -49,6 +49,10 @@ jobs:
 
       # checkout the repo
       - uses: actions/checkout@v2
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
 
       # copy the podspec template to its final destination
       - name: Copy the podspec template
@@ -77,10 +81,6 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: 'ios/Cartfile.resolved'
-
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
 
       # open a pull request with the new sdk version
       - name: Create Pull Request


### PR DESCRIPTION
## Summary
The `npm version` in the auto-version bump Github action was failing because, by default, `npm version` makes a commit and creates a tag. 

Fortunately, these [options can be bypassed](https://docs.npmjs.com/cli/v7/commands/npm-version#git-tag-version) so these changes can just be included with the PR's changes.