### PR TITLE
Fix example app metro config

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,3 +1,5 @@
+// https://github.com/callstack/react-native-builder-bob
+
 const exclusionList = require('metro-config/src/defaults/exclusionList');
 
 const path = require('path');

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,19 +1,39 @@
-// https://github.com/facebook/react-native/issues/24065#issuecomment-537489786
+const exclusionList = require('metro-config/src/defaults/exclusionList');
 
-const blacklist = require('metro-config/src/defaults/exclusionList');
+const path = require('path');
+const escape = require('escape-string-regexp');
+const { getDefaultConfig } = require('@expo/metro-config');
+const pak = require('../package.json');
+
+const root = path.resolve(__dirname, '..');
+
+const modules = Object.keys({
+  ...pak.peerDependencies,
+});
+
+const defaultConfig = getDefaultConfig(__dirname);
 
 module.exports = {
+  ...defaultConfig,
+
+  projectRoot: __dirname,
+  watchFolders: [root],
+
+  // We need to make sure that only one version is loaded for peerDependencies
+  // So we block them at the root, and alias them to the versions in example's node_modules
   resolver: {
-    blacklistRE: blacklist([
-      /node_modules\/.*\/node_modules\/react-native\/.*/,
-    ])
-  },
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: false,
-      },
-    }),
+    ...defaultConfig.resolver,
+
+    blacklistRE: exclusionList(
+      modules.map(
+        (m) =>
+          new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
+      )
+    ),
+
+    extraNodeModules: modules.reduce((acc, name) => {
+      acc[name] = path.join(__dirname, 'node_modules', name);
+      return acc;
+    }, {}),
   },
 };

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -15,22 +15,16 @@ const defaultConfig = getDefaultConfig(__dirname);
 
 module.exports = {
   ...defaultConfig,
-
   projectRoot: __dirname,
   watchFolders: [root],
-
-  // We need to make sure that only one version is loaded for peerDependencies
-  // So we block them at the root, and alias them to the versions in example's node_modules
   resolver: {
     ...defaultConfig.resolver,
-
     blacklistRE: exclusionList(
       modules.map(
         (m) =>
           new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
       )
     ),
-
     extraNodeModules: modules.reduce((acc, name) => {
       acc[name] = path.join(__dirname, 'node_modules', name);
       return acc;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "url": "https://github.com/radarlabs/react-native-radar.git"
   },
   "dependencies": {
-    "radar-sdk-js": "^3.5.0",
-    "@react-native-community/netinfo": "^7.1.3"
+    "@babel/runtime": "^7.21.0",
+    "@react-native-community/netinfo": "^7.1.3",
+    "radar-sdk-js": "^3.5.0"
   }
 }


### PR DESCRIPTION
Fixes MOB-88.

Our metro configuration for our sample app is currently broken (`Error: Unable to resolve module react-native-radar`). This fixes it.