### PR TITLE
Update scheduledArrivalAt handling on iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   android:
     working_directory: ~/react-native-radar/example
     docker:
-      - image: circleci/android:2023.06.1-node
+      - image: cimg/android:2023.06-node
     steps:
       - checkout:
           path: ~/react-native-radar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   android:
     working_directory: ~/react-native-radar/example
     docker:
-      - image: cimg/android:2023.06-node
+      - image: cimg/android:2023.02.1-browsers
     steps:
       - checkout:
           path: ~/react-native-radar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   android:
     working_directory: ~/react-native-radar/example
     docker:
-      - image: circleci/android:api-28-node
+      - image: circleci/android:2023.06.1-node
     steps:
       - checkout:
           path: ~/react-native-radar

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.7.4'
+        versionName '3.7.5'
     }
     lintOptions {
         abortOnError false
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.3'
+    api 'io.radar:sdk:3.8.4'
 }

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "radarlabs/radar-sdk-ios" "3.7.8"
+github "radarlabs/radar-sdk-ios" "3.8.1"

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -415,10 +415,6 @@ RCT_EXPORT_METHOD(startTrip:(NSDictionary *)optionsDict resolve:(RCTPromiseResol
     if (tripOptionsDict == nil) {
         tripOptionsDict = optionsDict;
     }
-    NSObject *scheduledArrivalAtObj = tripOptionsDict[@"scheduledArrivalAt"];
-    if (scheduledArrivalAtObj && [scheduledArrivalAtObj isKindOfClass:[NSNumber class]]) {
-        [tripOptionsDict setObject:[RCTConvert NSDate:scheduledArrivalAtObj] forKey:@"scheduledArrivalAt"];
-    }
 
     RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
     
@@ -507,11 +503,6 @@ RCT_EXPORT_METHOD(updateTrip:(NSDictionary *)optionsDict resolve:(RCTPromiseReso
     }
 
     NSMutableDictionary *tripOptionsDict = optionsDict[@"options"];
-
-    NSObject *scheduledArrivalAtObj = tripOptionsDict[@"scheduledArrivalAt"];
-    if (scheduledArrivalAtObj && [scheduledArrivalAtObj isKindOfClass:[NSNumber class]]) {
-        [tripOptionsDict setObject:[RCTConvert NSDate:scheduledArrivalAtObj] forKey:@"scheduledArrivalAt"];
-    }
 
     RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
     NSString *statusStr = optionsDict[@"status"];

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -411,7 +411,7 @@ RCT_EXPORT_METHOD(getTripOptions:(RCTPromiseResolveBlock)resolve reject:(RCTProm
 RCT_EXPORT_METHOD(startTrip:(NSDictionary *)optionsDict resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     // { tripOptions, trackingOptions } is the new req format.
     // fallback to reading trip options from the top level options.
-    NSMutableDictionary *tripOptionsDict = optionsDict[@"tripOptions"];
+    NSDictionary *tripOptionsDict = optionsDict[@"tripOptions"];
     if (tripOptionsDict == nil) {
         tripOptionsDict = optionsDict;
     }
@@ -502,9 +502,7 @@ RCT_EXPORT_METHOD(updateTrip:(NSDictionary *)optionsDict resolve:(RCTPromiseReso
         return;
     }
 
-    NSMutableDictionary *tripOptionsDict = optionsDict[@"options"];
-
-    RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
+    RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:optionsDict[@"options"]];
     NSString *statusStr = optionsDict[@"status"];
 
     RadarTripStatus status = RadarTripStatusUnknown;

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -411,14 +411,17 @@ RCT_EXPORT_METHOD(getTripOptions:(RCTPromiseResolveBlock)resolve reject:(RCTProm
 RCT_EXPORT_METHOD(startTrip:(NSDictionary *)optionsDict resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     // { tripOptions, trackingOptions } is the new req format.
     // fallback to reading trip options from the top level options.
-    NSDictionary *tripOptionsDict = optionsDict[@"tripOptions"];
+    NSMutableDictionary *tripOptionsDict = optionsDict[@"tripOptions"];
     if (tripOptionsDict == nil) {
         tripOptionsDict = optionsDict;
     }
-    RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
-    if (options.scheduledArrivalAt) {
-        options.scheduledArrivalAt = [RCTConvert NSDate:options.scheduledArrivalAt];
+    NSObject *scheduledArrivalAtObj = tripOptionsDict[@"scheduledArrivalAt"];
+    if (scheduledArrivalAtObj && [scheduledArrivalAtObj isKindOfClass:[NSNumber class]]) {
+        [tripOptionsDict setObject:[RCTConvert NSDate:scheduledArrivalAtObj] forKey:@"scheduledArrivalAt"];
     }
+
+    RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
+    
     RadarTrackingOptions *trackingOptions;
     NSDictionary *trackingOptionsDict = optionsDict[@"trackingOptions"];
     if (trackingOptionsDict != nil) {
@@ -503,7 +506,14 @@ RCT_EXPORT_METHOD(updateTrip:(NSDictionary *)optionsDict resolve:(RCTPromiseReso
         return;
     }
 
-    RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:optionsDict[@"options"]];
+    NSMutableDictionary *tripOptionsDict = optionsDict[@"options"];
+
+    NSObject *scheduledArrivalAtObj = tripOptionsDict[@"scheduledArrivalAt"];
+    if (scheduledArrivalAtObj && [scheduledArrivalAtObj isKindOfClass:[NSNumber class]]) {
+        [tripOptionsDict setObject:[RCTConvert NSDate:scheduledArrivalAtObj] forKey:@"scheduledArrivalAt"];
+    }
+
+    RadarTripOptions *options = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
     NSString *statusStr = optionsDict[@"status"];
 
     RadarTripStatus status = RadarTripStatusUnknown;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.7.4",
+      "version": "3.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "main": "js/index.js",
   "files": [
     "android",

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.7.8"
+  s.dependency "RadarSDK", "~> 3.8.0"
 end

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.8.0"
+  s.dependency "RadarSDK", "~> 3.8.1"
 end


### PR DESCRIPTION
I initially was fixing with a change to `RadarTripOptions.m`, but figured that isolating the changes to just react native would be best.

I've confirmed the change via Waypoint. It now works with `arrivalTime.getTime()` as we had in the example in this repo, as well as `arrivalTime.toIsoString()` which was undocumented but working on Android.

As far as I can, both Android and iOS handle both datetime formats now, but I'll put through some reps on an Android build over the weekend to triple confirm.