### PR TITLE
Fix github release process

### DIFF
--- a/.github/workflows/radar-pre-release-actions.yml
+++ b/.github/workflows/radar-pre-release-actions.yml
@@ -12,8 +12,8 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: npm ci --force
       - run: npm run check-beta-tag
-      - run: npm ci
       - run: npm publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/radar-pre-release-actions.yml
+++ b/.github/workflows/radar-pre-release-actions.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci --force
+      - run: npm ci
       - run: npm run check-beta-tag
       - run: npm publish --tag beta
         env:

--- a/.github/workflows/radar-pre-release-actions.yml
+++ b/.github/workflows/radar-pre-release-actions.yml
@@ -1,7 +1,7 @@
 name: Publish Package to npmjs
 on:
   release:
-    types: [ released ]
+    types: [ prereleased ]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,8 +12,8 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm run check-latest-tag
+      - run: npm run check-beta-tag
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/radar-pre-release-actions.yml
+++ b/.github/workflows/radar-pre-release-actions.yml
@@ -1,4 +1,4 @@
-name: Publish Package to npmjs
+name: Publish beta package to npmjs
 on:
   release:
     types: [ prereleased ]

--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -1,4 +1,4 @@
-name: Publish Package to npmjs
+name: Publish latest package to npmjs
 on:
   release:
     types: [ released ]

--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -12,8 +12,8 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: npm ci --force
       - run: npm run check-latest-tag
-      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci --force
+      - run: npm ci
       - run: npm run check-latest-tag
       - run: npm publish
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.2",
+      "version": "3.8.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "main": "js/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "react-native-radar.podspec"
   ],
   "scripts": {
-    "test": "jest ./test/*.test.js"
+    "test": "jest ./test/*.test.js",
+    "check-latest-tag": "node ./scripts/check-latest-tag.cjs",
+    "check-beta-tag": "node ./scripts/check-beta-tag.cjs"
   },
   "jest": {
     "preset": "react-native",

--- a/scripts/check-beta-tag.cjs
+++ b/scripts/check-beta-tag.cjs
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const packageJSON = require('../package.json');
+const packageLockJSON = require('../package-lock.json');
+
+let tagVersion = process.env.GITHUB_REF_NAME || '';
+console.log('Checking tag:', tagVersion);
+
+
+if (!tagVersion.includes('-beta')) {
+  console.error('Prelease version should contiain a "-beta" suffix');
+  process.exit(1);
+}
+
+if (tagVersion !== packageJSON.version) {
+  console.error('VERSION MISMATCH - version does not match package.json.');
+  process.exit(1);
+}
+if (tagVersion !== packageLockJSON.version) {
+  console.error('VERSION MISMATCH - version does not match package-lock.json.');
+  process.exit(1);
+}
+console.log('Tag OK.', tagVersion);

--- a/scripts/check-beta-tag.cjs
+++ b/scripts/check-beta-tag.cjs
@@ -7,7 +7,7 @@ console.log('Checking tag:', tagVersion);
 
 
 if (!tagVersion.includes('-beta')) {
-  console.error('Prelease version should contiain a "-beta" suffix');
+  console.error('Prelease version should contain a "-beta" suffix');
   process.exit(1);
 }
 

--- a/scripts/check-latest-tag.cjs
+++ b/scripts/check-latest-tag.cjs
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const packageJSON = require('../package.json');
+const packageLockJSON = require('../package-lock.json');
+
+let tagVersion = process.env.GITHUB_REF_NAME || '';
+console.log('Checking tag:', tagVersion);
+
+if (!tagVersion.startsWith('v')) {
+  console.error('Tag must start with "v"');
+  process.exit(1);
+}
+if (tagVersion.includes('-')) {
+  console.error('Latest tag should not include any suffix:', `-${tagVersion.split('-')[1]}`);
+  process.exit(1);
+}
+
+if (tagVersion !== packageJSON.version) {
+  console.error('VERSION MISMATCH - version does not match package.json.');
+  process.exit(1);
+}
+if (tagVersion !== packageLockJSON.version) {
+  console.error('VERSION MISMATCH - version does not match package-lock.json.');
+  process.exit(1);
+}
+console.log('Tag OK.', tagVersion);

--- a/scripts/check-latest-tag.cjs
+++ b/scripts/check-latest-tag.cjs
@@ -5,10 +5,7 @@ const packageLockJSON = require('../package-lock.json');
 let tagVersion = process.env.GITHUB_REF_NAME || '';
 console.log('Checking tag:', tagVersion);
 
-if (!tagVersion.startsWith('v')) {
-  console.error('Tag must start with "v"');
-  process.exit(1);
-}
+
 if (tagVersion.includes('-')) {
   console.error('Latest tag should not include any suffix:', `-${tagVersion.split('-')[1]}`);
   process.exit(1);


### PR DESCRIPTION
Presently our github actions release pre-releases as `latest`. These changes ensure that beta / pre-releases get marked as such so that `npm install react-native-radar` only installs the latest, non beta versions.