### PR TITLE
Kennyhu/fence 1213 update sdk to show if remote tracking is turned on

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.7'
+    api 'io.radar:sdk:3.8.8'
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -494,6 +494,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
+    public void isUsingRemoteTrackingOptions(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+
+        promise.resolve(Radar.isUsingRemoteTrackingOptions());
+    }
+
+    @ReactMethod
     public void setForegroundServiceOptions(ReadableMap optionsMap) {
         try {
             JSONObject optionsObj = RNRadarUtils.jsonForMap(optionsMap);

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -407,6 +407,11 @@ RCT_EXPORT_METHOD(isTracking:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseR
     resolve(@(res));
 }
 
+RCT_EXPORT_METHOD(isUsingRemoteTrackingOptions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    BOOL res = [Radar isUsingRemoteTrackingOptions];
+    resolve(@(res));
+}
+
 RCT_EXPORT_METHOD(getTrackingOptions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     if (resolve == nil) {
         return;

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -208,6 +208,7 @@ const Radar = {
   setMetadata,
   getMetadata,
   setAnonymousTrackingEnabled,
+  isUsingRemoteTrackingOptions,
   getPermissionsStatus,
   requestPermissions,
   getLocation,

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -102,6 +102,10 @@ const getTrackingOptions = () => (
   NativeModules.RNRadar.getTrackingOptions()
 )
 
+const isUsingRemoteTrackingOptions = () => (
+  NativeModules.RNRadar.isUsingRemoteTrackingOptions()
+)
+
 const isTracking = () => (
   NativeModules.RNRadar.isTracking()
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.6",
+      "version": "3.8.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "main": "js/index.js",
   "files": [
     "android",


### PR DESCRIPTION
QA for correctness of SDK changes 
steps taken

- RTO turned off at dashboard
- start app to verify that RTO is indicated as off, close app
- RTO turn on at dashboard
- start app to verify that RTO is indicated as on, close app
- RTO turned off at dashboard
- start app to verify that RTO is indicated as off, close app
IOS:
<img width="427" alt="image" src="https://github.com/radarlabs/react-native-radar/assets/139801512/026d96ca-8b41-43d7-9653-4edf3c271c6a">
<img width="442" alt="image" src="https://github.com/radarlabs/react-native-radar/assets/139801512/fed3a75a-183a-478a-8677-a696f3359664">
Android:
<img width="404" alt="image" src="https://github.com/radarlabs/react-native-radar/assets/139801512/e6c4c0e2-bb0a-49a2-840f-96474a9b15a5">

<img width="406" alt="image" src="https://github.com/radarlabs/react-native-radar/assets/139801512/a54897ea-e925-4e6b-9060-b3685a3dcabf">

