### PR TITLE
3.8.9, bump iOS to 3.8.7, android to 3.8.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.8.8'
+        versionName '3.8.9'
     }
     lintOptions {
         abortOnError false
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.9'
+    api 'io.radar:sdk:3.8.10'
 }

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "radarlabs/radar-sdk-ios" "3.8.6"
+github "radarlabs/radar-sdk-ios" "3.8.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.8",
+      "version": "3.8.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "main": "js/index.js",
   "files": [
     "android",

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.8.6"
+  s.dependency "RadarSDK", "~> 3.8.7"
 end


### PR DESCRIPTION
Tests won't pass until new native SDKs hit their package managers.