### PR TITLE
Shift when Radar.initialize is called in example app

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -9,6 +9,7 @@ MapLibreGL.setAccessToken(null);
 const stringify = (obj) => JSON.stringify(obj, null, 2);
 
 Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
+
 Radar.setLogLevel("info");
 
 Radar.setUserId("foo");

--- a/example/App.js
+++ b/example/App.js
@@ -8,6 +8,8 @@ MapLibreGL.setAccessToken(null);
 
 const stringify = (obj) => JSON.stringify(obj, null, 2);
 
+Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
+
 Radar.on("events", (result) => {
   console.log("events:", stringify(result));
 });
@@ -39,7 +41,6 @@ export default function App() {
   const stringify = (obj) => JSON.stringify(obj, null, 2);
 
   useEffect(() => {
-    Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
 
     Radar.setLogLevel("info");
 

--- a/example/App.js
+++ b/example/App.js
@@ -9,6 +9,17 @@ MapLibreGL.setAccessToken(null);
 const stringify = (obj) => JSON.stringify(obj, null, 2);
 
 Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
+Radar.setLogLevel("info");
+
+Radar.setUserId("foo");
+
+Radar.setDescription("description");
+
+Radar.setMetadata({
+  foo: "bar",
+  baz: true,
+  qux: 1,
+});
 
 Radar.on("events", (result) => {
   console.log("events:", stringify(result));
@@ -42,17 +53,7 @@ export default function App() {
 
   useEffect(() => {
 
-    Radar.setLogLevel("info");
 
-    Radar.setUserId("foo");
-
-    Radar.setDescription("description");
-
-    Radar.setMetadata({
-      foo: "bar",
-      baz: true,
-      qux: 1,
-    });
   }, []);
 
   return (


### PR DESCRIPTION
`Radar.initialize` is moved from being called inside useEffect to outside of App to prevent Map from trying to load before `Radar.initialize` is called