### PR TITLE
Catch Map element possible permissions error

### DIFF
--- a/js/ui/map.jsx
+++ b/js/ui/map.jsx
@@ -31,13 +31,12 @@ const RadarMap = ({ mapOptions, children }) => {
 
   useEffect(() => {
     Radar.getLocation().then((result) => {
-      if (!result.location || !result.location.latitude || !result.location.longitude) {
-        return;
+      if (result?.location?.latitude && result?.location?.longitude) {
+        setUserLocation({
+          latitude: result.location.latitude,
+          longitude: result.location.longitude,
+        });
       }
-      setUserLocation({
-        latitude: result.location.latitude,
-        longitude: result.location.longitude,
-      });
     }).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn(`Radar SDK: Failed to get location: ${err}`);

--- a/js/ui/map.jsx
+++ b/js/ui/map.jsx
@@ -31,10 +31,16 @@ const RadarMap = ({ mapOptions, children }) => {
 
   useEffect(() => {
     Radar.getLocation().then((result) => {
+      if (!result.location || !result.location.latitude || !result.location.longitude) {
+        return;
+      }
       setUserLocation({
         latitude: result.location.latitude,
         longitude: result.location.longitude,
       });
+    }).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn(`Radar SDK: Failed to get location: ${err}`);
     });
   }, [mapOptions]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.9",
+  "version": "3.8.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.9",
+      "version": "3.8.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.9",
+  "version": "3.8.10",
   "main": "js/index.js",
   "files": [
     "android",


### PR DESCRIPTION
The map element requests location for the location indicator, but we can't be sure that we have the necessary permissions.

The `react-native-radar` sdk doesn't do full permission monitoring, so the safest thing to do is to attempt to get the location and fail gracefully.

I'm presently `console.warn`-ing, but we probably should replicate the [logger](https://github.com/radarlabs/radar-sdk-js/blob/master/src/logger.ts) used in the js sdk sometime soon. 