### PR TITLE
Kennyhu/fence 1283 setloglevel in react native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.10'
+    api 'io.radar:sdk:3.8.11-beta.3' 
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -109,8 +109,29 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         if (promise == null) {
             return;
         }
+        Radar.RadarLogLevel currentLogLevel = Radar.getLogLevel();
+        String levelString = "";
+    
+        switch (currentLogLevel) {
+            case ERROR:
+                levelString = "ERROR";
+                break;
+            case WARNING:
+                levelString = "WARNING";
+                break;
+            case INFO:
+                levelString = "INFO";
+                break;
+            case DEBUG:
+                levelString = "DEBUG";
+                break;
+            default:
+                levelString = "NONE";
+                break;
+        }
 
-        promise.resolve(Radar.getLogLevel());
+
+        promise.resolve(levelString);
     }
 
     @ReactMethod

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -105,6 +105,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
+    public void getLogLevel(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+
+        promise.resolve(Radar.getLogLevel());
+    }
+
+    @ReactMethod
     public void setUserId(String userId) {
         Radar.setUserId(userId);
     }

--- a/example/App.js
+++ b/example/App.js
@@ -39,7 +39,10 @@ export default function App() {
   const stringify = (obj) => JSON.stringify(obj, null, 2);
 
   useEffect(() => {
-    Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
+    Radar.initialize(
+      "prj_test_pk_0000000000000000000000000000000000000000",
+      true
+    );
 
     Radar.setLogLevel("info");
 
@@ -83,6 +86,19 @@ export default function App() {
                 })
                 .catch((err) => {
                   handlePopulateText("getUserId:" + err);
+                });
+            }}
+          />
+
+          <ExampleButton
+            title="getLogLevel"
+            onPress={() => {
+              Radar.getLogLevel()
+                .then((result) => {
+                  handlePopulateText("getLogLevel:" + result);
+                })
+                .catch((err) => {
+                  handlePopulateText("getLogLevel:" + err);
                 });
             }}
           />

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -111,6 +111,10 @@ RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {
     [Radar setLogLevel:logLevel];
 }
 
+RCT_EXPORT_METHOD(getLogLevel:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    resolve([Radar getLogLevel]);
+}
+
 RCT_EXPORT_METHOD(setUserId:(NSString *)userId) {
     [Radar setUserId:userId];
 }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -112,7 +112,29 @@ RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {
 }
 
 RCT_EXPORT_METHOD(getLogLevel:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    resolve([Radar getLogLevel]);
+   RadarLogLevel logLevel = [Radar getLogLevel];
+    NSString *logLevelString;
+    
+    switch (logLevel) {
+        case RadarLogLevelNone:
+            logLevelString = @"NONE";
+            break;
+        case RadarLogLevelError:
+            logLevelString = @"ERROR";
+            break;
+        case RadarLogLevelWarning:
+            logLevelString = @"WARNING";
+            break;
+        case RadarLogLevelInfo:
+            logLevelString = @"INFO";
+            break;
+        default:
+            logLevelString = @"DEBUG";
+            break;
+    }
+     NSLog(@"Current log level: %@", logLevelString); 
+    NSString *fetchedData = @"This is the fetched data";
+    resolve(fetchedData);
 }
 
 RCT_EXPORT_METHOD(setUserId:(NSString *)userId) {

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -132,9 +132,7 @@ RCT_EXPORT_METHOD(getLogLevel:(RCTPromiseResolveBlock)resolve reject:(RCTPromise
             logLevelString = @"DEBUG";
             break;
     }
-     NSLog(@"Current log level: %@", logLevelString); 
-    NSString *fetchedData = @"This is the fetched data";
-    resolve(fetchedData);
+    resolve(logLevelString);
 }
 
 RCT_EXPORT_METHOD(setUserId:(NSString *)userId) {

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -14,9 +14,9 @@ const setLogLevel = (level) => {
   NativeModules.RNRadar.setLogLevel(level);
 };
 
-const getLogLevel = () => {
+const getLogLevel = () => (
   NativeModules.RNRadar.getLogLevel()
-};
+);
 
 const setUserId = (userId) => {
   NativeModules.RNRadar.setUserId(userId);

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -14,6 +14,10 @@ const setLogLevel = (level) => {
   NativeModules.RNRadar.setLogLevel(level);
 };
 
+const getLogLevel = ()=>{
+  NativeModules.RNRadar.getLogLevel();
+}
+
 const setUserId = (userId) => {
   NativeModules.RNRadar.setUserId(userId);
 };
@@ -200,6 +204,7 @@ const off = (event, callback) => {
 
 const Radar = {
   initialize,
+  setLogLevel,
   setLogLevel,
   setUserId,
   getUserId,

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -14,9 +14,9 @@ const setLogLevel = (level) => {
   NativeModules.RNRadar.setLogLevel(level);
 };
 
-const getLogLevel = ()=>{
-  NativeModules.RNRadar.getLogLevel();
-}
+const getLogLevel = () => {
+  NativeModules.RNRadar.getLogLevel()
+};
 
 const setUserId = (userId) => {
   NativeModules.RNRadar.setUserId(userId);
@@ -205,7 +205,7 @@ const off = (event, callback) => {
 const Radar = {
   initialize,
   setLogLevel,
-  setLogLevel,
+  getLogLevel,
   setUserId,
   getUserId,
   setDescription,


### PR DESCRIPTION
QA:
taken from waypoint, a print statement is created using this endpoint to verify correctness 
`  useEffect(() => {
     Radar.getLogLevel().then((result) =>
      console.log('log level is ', result)
     );
  }, []);` 
and 
`Radar.setLogLevel('warning');` (in the initializing page)

Able to get these logs
IOS: 
<img width="321" alt="Screenshot 2023-09-13 at 3 58 24 PM" src="https://github.com/radarlabs/react-native-radar/assets/139801512/2207786a-2c5e-4a97-94ba-11b9469479c4">

Android: 
![image](https://github.com/radarlabs/react-native-radar/assets/139801512/65001bfd-e95b-4d9f-9211-5e821653ac02)


