### PR TITLE
implemented endpoints for getting versioning for RN and native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.8.11'
+        versionName '3.8.12'
     }
     lintOptions {
         abortOnError false
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.11'
+    api 'io.radar:sdk:3.8.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,7 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName '3.8.11'
+        buildConfigField "String", "NATIVE_VERSION", "\"${radarNativeVersion}\""
     }
     lintOptions {
         abortOnError false
@@ -45,5 +46,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.11'
+    api "io.radar:sdk:${radarNativeVersion}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,6 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName '3.8.11'
-        buildConfigField "String", "NATIVE_VERSION", "\"${radarNativeVersion}\""
     }
     lintOptions {
         abortOnError false
@@ -46,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api "io.radar:sdk:${radarNativeVersion}"
+    api "io.radar:sdk:3.8.11"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api "io.radar:sdk:3.8.11"
+    api 'io.radar:sdk:3.8.11'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,2 @@
 android.useAndroidX=true
+radarNativeVersion=3.8.11

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,1 @@
 android.useAndroidX=true
-radarNativeVersion=3.8.11

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -142,7 +142,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         if (myProperty != null) {
             promise.resolve(myProperty); 
         } else {
-            promise.resolve(Radar.getUserId());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -137,10 +137,10 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         if (promise == null) {
             return;
         }
-        String myProperty = BuildConfig.NATIVE_VERSION;
+        String sdkVersion = Radar.sdkVersion();
 
-        if (myProperty != null) {
-            promise.resolve(myProperty); 
+        if (sdkVersion != null) {
+            promise.resolve(sdkVersion); 
         } else {
             promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -40,7 +40,6 @@ import org.json.JSONObject;
 
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.Properties;
 
 public class RNRadarModule extends ReactContextBaseJavaModule implements PermissionListener {
 
@@ -81,8 +80,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     @ReactMethod
     public void initialize(String publishableKey, boolean fraud) {
         if (fraud) {
-            Radar.initialize(getReactApplicationContext(), publishableKey, receiver,
-                    Radar.RadarLocationServicesProvider.GOOGLE, fraud);
+            Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud);
         } else {
             Radar.initialize(getReactApplicationContext(), publishableKey);
             Radar.setReceiver(receiver);
@@ -121,21 +119,6 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
-    public void nativeSdkVersion(final Promise promise) {
-        if (promise == null) {
-            return;
-        }
-
-        String myProperty = BuildConfig.NATIVE_VERSION;
-
-        if (myProperty != null) {
-            promise.resolve(myProperty); 
-        } else {
-            promise.resolve(Radar.getUserId());
-        }
-    }
-
-    @ReactMethod
     public void setDescription(String description) {
         Radar.setDescription(description);
     }
@@ -150,17 +133,31 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
+    public void nativeSdkVersion(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+        String myProperty = BuildConfig.NATIVE_VERSION;
+
+        if (myProperty != null) {
+            promise.resolve(myProperty); 
+        } else {
+            promise.resolve(Radar.getUserId());
+        }
+    }
+
+    @ReactMethod
     public void setMetadata(ReadableMap metadataMap) throws JSONException {
         Radar.setMetadata(RNRadarUtils.jsonForMap(metadataMap));
     }
 
     @ReactMethod
-    public void getMetadata(final Promise promise) throws JSONException {
+    public void getMetadata(final Promise promise) throws JSONException {        
         if (promise == null) {
             return;
         }
 
-        JSONObject metaJson = Radar.getMetadata();
+        JSONObject metaJson =  Radar.getMetadata();        
         promise.resolve(RNRadarUtils.mapForJson(metaJson));
     }
 
@@ -201,15 +198,12 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             return;
         }
 
-        boolean foreground = ActivityCompat.checkSelfPermission(activity,
-                Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+        boolean foreground = ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
         boolean background = foreground;
-        boolean denied = ActivityCompat.shouldShowRequestPermissionRationale(activity,
-                Manifest.permission.ACCESS_FINE_LOCATION);
-
+        boolean denied = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION);
+        
         if (Build.VERSION.SDK_INT >= 29) {
-            background = ActivityCompat.checkSelfPermission(activity,
-                    Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED;
+            background = ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED;
         }
 
         if (background) {
@@ -234,16 +228,14 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
     @ReactMethod
     public void requestPermissions(boolean background, final Promise promise) {
-        PermissionAwareActivity activity = (PermissionAwareActivity) getCurrentActivity();
+        PermissionAwareActivity activity = (PermissionAwareActivity)getCurrentActivity();
         mPermissionsRequestPromise = promise;
         if (activity != null) {
             if (Build.VERSION.SDK_INT >= 23) {
                 if (background && Build.VERSION.SDK_INT >= 29) {
-                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_BACKGROUND_LOCATION }, PERMISSIONS_REQUEST_CODE, this);
+                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION }, PERMISSIONS_REQUEST_CODE, this);
                 } else {
-                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION },
-                            PERMISSIONS_REQUEST_CODE, this);
+                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION }, PERMISSIONS_REQUEST_CODE, this);
                 }
             }
         }
@@ -251,10 +243,10 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
     @ReactMethod
     public void getLocation(String desiredAccuracy, final Promise promise) {
-
-        RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM;
-        String accuracy = desiredAccuracy != null ? desiredAccuracy.toLowerCase() : "medium";
-
+        
+        RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM;        
+        String accuracy = desiredAccuracy != null ? desiredAccuracy.toLowerCase()  : "medium";
+        
         if (accuracy.equals("low")) {
             accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW;
         } else if (accuracy.equals("medium")) {
@@ -262,8 +254,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         } else if (accuracy.equals("high")) {
             accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH;
         } else {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
 
         Radar.getLocation(accuracyLevel, new Radar.RadarLocationCallback() {
@@ -284,8 +275,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -296,7 +286,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
     @ReactMethod
     public void trackOnce(ReadableMap optionsMap, final Promise promise) {
-
+        
         Location location = null;
         RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM;
         boolean beaconsTrackingOption = false;
@@ -307,7 +297,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                 location = new Location("RNRadarModule");
                 double latitude = locationMap.getDouble("latitude");
                 double longitude = locationMap.getDouble("longitude");
-                float accuracy = (float) locationMap.getDouble("accuracy");
+                float accuracy = (float)locationMap.getDouble("accuracy");
                 location.setLatitude(latitude);
                 location.setLongitude(longitude);
                 location.setAccuracy(accuracy);
@@ -331,8 +321,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.RadarTrackCallback trackCallback = new Radar.RadarTrackCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
                 if (promise == null) {
                     return;
                 }
@@ -356,8 +345,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                            Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         };
@@ -373,8 +361,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     public void trackVerified(final Promise promise) {
         Radar.trackVerified(new Radar.RadarTrackCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
                 if (promise == null) {
                     return;
                 }
@@ -398,8 +385,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                            Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -427,8 +413,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (Exception e) {
                     Log.e(TAG, "Exception", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                            Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -488,8 +473,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.mockTracking(origin, destination, mode, steps, interval, new Radar.RadarTrackCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
 
             }
         });
@@ -517,7 +501,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         try {
             RadarTrackingOptions options = Radar.getTrackingOptions();
             promise.resolve(RNRadarUtils.mapForJson(options.toJson()));
-        } catch (JSONException e) {
+        } catch(JSONException e) {
             Log.e(TAG, "JSONException", e);
             promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
         }
@@ -561,7 +545,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         try {
             RadarTripOptions options = Radar.getTripOptions();
             promise.resolve(options != null ? RNRadarUtils.mapForJson(options.toJson()) : null);
-        } catch (JSONException e) {
+        } catch(JSONException e) {
             Log.e(TAG, "JSONException", e);
             promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
         }
@@ -574,8 +558,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             // new format is { tripOptions, trackingOptions }
             JSONObject tripOptionsJson = optionsJson.optJSONObject("tripOptions");
             if (tripOptionsJson == null) {
-                // legacy format
-                tripOptionsJson = optionsJson;
+              // legacy format
+              tripOptionsJson = optionsJson;
             }
             RadarTripOptions options = RadarTripOptions.fromJson(tripOptionsJson);
 
@@ -586,8 +570,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             }
             Radar.startTrip(options, trackingOptions, new Radar.RadarTripCallback() {
                 @Override
-                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
-                        @Nullable RadarEvent[] events) {
+                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
                     if (promise == null) {
                         return;
                     }
@@ -607,15 +590,13 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         }
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 }
             });
         } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
     }
 
@@ -623,8 +604,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     public void completeTrip(final Promise promise) {
         Radar.completeTrip(new Radar.RadarTripCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
-                    @Nullable RadarEvent[] events) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
                 if (promise == null) {
                     return;
                 }
@@ -644,8 +624,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                            Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -655,8 +634,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     public void cancelTrip(final Promise promise) {
         Radar.cancelTrip(new Radar.RadarTripCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
-                    @Nullable RadarEvent[] events) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
                 if (promise == null) {
                     return;
                 }
@@ -676,8 +654,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                            Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -707,19 +684,16 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     } else if (statusStr.equalsIgnoreCase("unknown")) {
                         status = RadarTrip.RadarTripStatus.UNKNOWN;
                     } else {
-                        promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                                Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
                     }
                 }
             } else {
-                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                        Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
             }
 
             Radar.updateTrip(options, status, new Radar.RadarTripCallback() {
                 @Override
-                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
-                        @Nullable RadarEvent[] events) {
+                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
                     if (promise == null) {
                         return;
                     }
@@ -739,15 +713,13 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         }
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 }
             });
         } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
     }
 
@@ -759,8 +731,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.getContext(new Radar.RadarContextCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarContext context) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarContext context) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -774,8 +745,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -798,8 +768,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.getContext(location, new Radar.RadarContextCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarContext context) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarContext context) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -813,8 +782,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -839,20 +807,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             near.setLongitude(longitude);
         }
         int radius = optionsMap.hasKey("radius") ? optionsMap.getInt("radius") : 1000;
-        String[] chains = optionsMap.hasKey("chains") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("chains"))
-                : null;
+        String[] chains = optionsMap.hasKey("chains") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("chains")) : null;
         Map<String, String> chainMetadata = RNRadarUtils.stringStringMap(optionsMap.getMap("chainMetadata"));
-        String[] categories = optionsMap.hasKey("categories")
-                ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("categories"))
-                : null;
-        String[] groups = optionsMap.hasKey("groups") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("groups"))
-                : null;
+        String[] categories = optionsMap.hasKey("categories") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("categories")) : null;
+        String[] groups = optionsMap.hasKey("groups") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("groups")) : null;
         int limit = optionsMap.hasKey("limit") ? optionsMap.getInt("limit") : 10;
 
         Radar.RadarSearchPlacesCallback callback = new Radar.RadarSearchPlacesCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarPlace[] places) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarPlace[] places) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -866,8 +829,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -898,16 +860,14 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             near.setLongitude(longitude);
         }
         int radius = optionsMap.hasKey("radius") ? optionsMap.getInt("radius") : 1000;
-        String[] tags = optionsMap.hasKey("tags") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("tags"))
-                : null;
+        String[] tags = optionsMap.hasKey("tags") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("tags")) : null;
         JSONObject metadata = null;
         if (optionsMap.hasKey("metadata")) {
             try {
                 metadata = RNRadarUtils.jsonForMap(optionsMap.getMap("metadata"));
             } catch (JSONException e) {
                 Log.e(TAG, "JSONException", e);
-                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                        Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
                 return;
             }
@@ -917,8 +877,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.RadarSearchGeofencesCallback callback = new Radar.RadarSearchGeofencesCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
-                    @Nullable RadarGeofence[] geofences) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarGeofence[] geofences) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -932,8 +891,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -955,8 +913,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         }
 
         if (!optionsMap.hasKey("query") || !optionsMap.hasKey("near")) {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
             return;
         }
@@ -969,14 +926,12 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         near.setLatitude(latitude);
         near.setLongitude(longitude);
         int limit = optionsMap.hasKey("limit") ? optionsMap.getInt("limit") : 10;
-        String country = optionsMap.hasKey("countryCode") ? optionsMap.getString("countryCode")
-                : optionsMap.hasKey("country") ? optionsMap.getString("country") : null;
-        String[] layers = optionsMap.hasKey("layers") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("layers"))
-                : null;
+        String country = optionsMap.hasKey("countryCode") ? optionsMap.getString("countryCode") : optionsMap.hasKey("country") ? optionsMap.getString("country") : null;
+        String[] layers = optionsMap.hasKey("layers") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("layers")) : null;
 
         boolean expandUnits = optionsMap.hasKey("expandUnits") ? optionsMap.getBoolean("expandUnits") : false;
 
-        Radar.autocomplete(query, near, layers, limit, country, expandUnits, new Radar.RadarGeocodeCallback() {
+        Radar.autocomplete(query, near, layers, limit, country, expandUnits,new Radar.RadarGeocodeCallback() {
             @Override
             public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarAddress[] addresses) {
                 if (status == Radar.RadarStatus.SUCCESS) {
@@ -989,8 +944,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1018,8 +972,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1047,8 +1000,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1088,8 +1040,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1118,8 +1069,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1135,8 +1085,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         }
 
         if (!optionsMap.hasKey("destination")) {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
             return;
         }
@@ -1156,8 +1105,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         Location destination = new Location("RNRadarModule");
         destination.setLatitude(latitude);
         destination.setLongitude(longitude);
-        String[] modesArr = optionsMap.hasKey("modes") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("modes"))
-                : new String[] {};
+        String[] modesArr = optionsMap.hasKey("modes") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("modes")) : new String[]{};
         EnumSet<Radar.RadarRouteMode> modes = EnumSet.noneOf(Radar.RadarRouteMode.class);
         for (String modeStr : modesArr) {
             if (modeStr.equals("FOOT") || modeStr.equals("foot")) {
@@ -1171,9 +1119,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             }
         }
         String unitsStr = optionsMap.hasKey("units") ? optionsMap.getString("units") : null;
-        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric"))
-                ? Radar.RadarRouteUnits.METRIC
-                : Radar.RadarRouteUnits.IMPERIAL;
+        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric")) ? Radar.RadarRouteUnits.METRIC : Radar.RadarRouteUnits.IMPERIAL;
 
         Radar.RadarRouteCallback callback = new Radar.RadarRouteCallback() {
             @Override
@@ -1188,8 +1134,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1248,9 +1193,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             }
         }
         String unitsStr = optionsMap.hasKey("units") ? optionsMap.getString("units") : null;
-        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric"))
-                ? Radar.RadarRouteUnits.METRIC
-                : Radar.RadarRouteUnits.IMPERIAL;
+        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric")) ? Radar.RadarRouteUnits.METRIC : Radar.RadarRouteUnits.IMPERIAL;
 
         Radar.getMatrix(origins, destinations, mode, units, new Radar.RadarMatrixCallback() {
             @Override
@@ -1265,8 +1208,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                                Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1276,14 +1218,13 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
-    public void logConversion(ReadableMap optionsMap, final Promise promise) throws JSONException {
+    public void logConversion(ReadableMap optionsMap, final Promise promise) throws JSONException  {
         if (promise == null) {
             return;
         }
 
         if (!optionsMap.hasKey("name")) {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
-                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
             return;
         }
@@ -1291,7 +1232,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         String name = optionsMap.getString("name");
         Double revenue = optionsMap.hasKey("revenue") ? new Double(optionsMap.getDouble("revenue")) : null;
         ReadableMap metadata = optionsMap.hasKey("metadata") ? optionsMap.getMap("metadata") : null;
-
+        
         JSONObject metadataObj = RNRadarUtils.jsonForMap(metadata);
         Radar.RadarLogConversionCallback callback = new Radar.RadarLogConversionCallback() {
             @Override
@@ -1309,8 +1250,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
-                            Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         };

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -40,6 +40,7 @@ import org.json.JSONObject;
 
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Properties;
 
 public class RNRadarModule extends ReactContextBaseJavaModule implements PermissionListener {
 
@@ -80,7 +81,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     @ReactMethod
     public void initialize(String publishableKey, boolean fraud) {
         if (fraud) {
-            Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud);
+            Radar.initialize(getReactApplicationContext(), publishableKey, receiver,
+                    Radar.RadarLocationServicesProvider.GOOGLE, fraud);
         } else {
             Radar.initialize(getReactApplicationContext(), publishableKey);
             Radar.setReceiver(receiver);
@@ -119,6 +121,21 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
+    public void nativeSdkVersion(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+
+        String myProperty = BuildConfig.NATIVE_VERSION;
+
+        if (myProperty != null) {
+            promise.resolve(myProperty); 
+        } else {
+            promise.resolve(Radar.getUserId());
+        }
+    }
+
+    @ReactMethod
     public void setDescription(String description) {
         Radar.setDescription(description);
     }
@@ -138,12 +155,12 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
-    public void getMetadata(final Promise promise) throws JSONException {        
+    public void getMetadata(final Promise promise) throws JSONException {
         if (promise == null) {
             return;
         }
 
-        JSONObject metaJson =  Radar.getMetadata();        
+        JSONObject metaJson = Radar.getMetadata();
         promise.resolve(RNRadarUtils.mapForJson(metaJson));
     }
 
@@ -184,12 +201,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             return;
         }
 
-        boolean foreground = ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+        boolean foreground = ActivityCompat.checkSelfPermission(activity,
+                Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
         boolean background = foreground;
-        boolean denied = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION);
-        
+        boolean denied = ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                Manifest.permission.ACCESS_FINE_LOCATION);
+
         if (Build.VERSION.SDK_INT >= 29) {
-            background = ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED;
+            background = ActivityCompat.checkSelfPermission(activity,
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED;
         }
 
         if (background) {
@@ -214,14 +234,16 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
     @ReactMethod
     public void requestPermissions(boolean background, final Promise promise) {
-        PermissionAwareActivity activity = (PermissionAwareActivity)getCurrentActivity();
+        PermissionAwareActivity activity = (PermissionAwareActivity) getCurrentActivity();
         mPermissionsRequestPromise = promise;
         if (activity != null) {
             if (Build.VERSION.SDK_INT >= 23) {
                 if (background && Build.VERSION.SDK_INT >= 29) {
-                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION }, PERMISSIONS_REQUEST_CODE, this);
+                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_BACKGROUND_LOCATION }, PERMISSIONS_REQUEST_CODE, this);
                 } else {
-                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION }, PERMISSIONS_REQUEST_CODE, this);
+                    activity.requestPermissions(new String[] { Manifest.permission.ACCESS_FINE_LOCATION },
+                            PERMISSIONS_REQUEST_CODE, this);
                 }
             }
         }
@@ -229,10 +251,10 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
     @ReactMethod
     public void getLocation(String desiredAccuracy, final Promise promise) {
-        
-        RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM;        
-        String accuracy = desiredAccuracy != null ? desiredAccuracy.toLowerCase()  : "medium";
-        
+
+        RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM;
+        String accuracy = desiredAccuracy != null ? desiredAccuracy.toLowerCase() : "medium";
+
         if (accuracy.equals("low")) {
             accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW;
         } else if (accuracy.equals("medium")) {
@@ -240,7 +262,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         } else if (accuracy.equals("high")) {
             accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH;
         } else {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
 
         Radar.getLocation(accuracyLevel, new Radar.RadarLocationCallback() {
@@ -261,7 +284,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -272,7 +296,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
     @ReactMethod
     public void trackOnce(ReadableMap optionsMap, final Promise promise) {
-        
+
         Location location = null;
         RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy accuracyLevel = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM;
         boolean beaconsTrackingOption = false;
@@ -283,7 +307,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                 location = new Location("RNRadarModule");
                 double latitude = locationMap.getDouble("latitude");
                 double longitude = locationMap.getDouble("longitude");
-                float accuracy = (float)locationMap.getDouble("accuracy");
+                float accuracy = (float) locationMap.getDouble("accuracy");
                 location.setLatitude(latitude);
                 location.setLongitude(longitude);
                 location.setAccuracy(accuracy);
@@ -307,7 +331,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.RadarTrackCallback trackCallback = new Radar.RadarTrackCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarEvent[] events, @Nullable RadarUser user) {
                 if (promise == null) {
                     return;
                 }
@@ -331,7 +356,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                            Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         };
@@ -347,7 +373,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     public void trackVerified(final Promise promise) {
         Radar.trackVerified(new Radar.RadarTrackCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarEvent[] events, @Nullable RadarUser user) {
                 if (promise == null) {
                     return;
                 }
@@ -371,7 +398,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                            Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -399,7 +427,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (Exception e) {
                     Log.e(TAG, "Exception", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                            Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -459,7 +488,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.mockTracking(origin, destination, mode, steps, interval, new Radar.RadarTrackCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarEvent[] events, @Nullable RadarUser user) {
 
             }
         });
@@ -487,7 +517,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         try {
             RadarTrackingOptions options = Radar.getTrackingOptions();
             promise.resolve(RNRadarUtils.mapForJson(options.toJson()));
-        } catch(JSONException e) {
+        } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
             promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
         }
@@ -531,7 +561,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         try {
             RadarTripOptions options = Radar.getTripOptions();
             promise.resolve(options != null ? RNRadarUtils.mapForJson(options.toJson()) : null);
-        } catch(JSONException e) {
+        } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
             promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
         }
@@ -544,8 +574,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             // new format is { tripOptions, trackingOptions }
             JSONObject tripOptionsJson = optionsJson.optJSONObject("tripOptions");
             if (tripOptionsJson == null) {
-              // legacy format
-              tripOptionsJson = optionsJson;
+                // legacy format
+                tripOptionsJson = optionsJson;
             }
             RadarTripOptions options = RadarTripOptions.fromJson(tripOptionsJson);
 
@@ -556,7 +586,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             }
             Radar.startTrip(options, trackingOptions, new Radar.RadarTripCallback() {
                 @Override
-                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
+                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
+                        @Nullable RadarEvent[] events) {
                     if (promise == null) {
                         return;
                     }
@@ -576,13 +607,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         }
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 }
             });
         } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
     }
 
@@ -590,7 +623,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     public void completeTrip(final Promise promise) {
         Radar.completeTrip(new Radar.RadarTripCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
+                    @Nullable RadarEvent[] events) {
                 if (promise == null) {
                     return;
                 }
@@ -610,7 +644,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                            Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -620,7 +655,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     public void cancelTrip(final Promise promise) {
         Radar.cancelTrip(new Radar.RadarTripCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
+                    @Nullable RadarEvent[] events) {
                 if (promise == null) {
                     return;
                 }
@@ -640,7 +676,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                            Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         });
@@ -670,16 +707,19 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     } else if (statusStr.equalsIgnoreCase("unknown")) {
                         status = RadarTrip.RadarTripStatus.UNKNOWN;
                     } else {
-                        promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                                Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
                     }
                 }
             } else {
-                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                        Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
             }
 
             Radar.updateTrip(options, status, new Radar.RadarTripCallback() {
                 @Override
-                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip, @Nullable RadarEvent[] events) {
+                public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarTrip trip,
+                        @Nullable RadarEvent[] events) {
                     if (promise == null) {
                         return;
                     }
@@ -699,13 +739,15 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         }
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 }
             });
         } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
         }
     }
 
@@ -717,7 +759,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.getContext(new Radar.RadarContextCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarContext context) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarContext context) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -731,7 +774,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -754,7 +798,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.getContext(location, new Radar.RadarContextCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarContext context) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarContext context) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -768,7 +813,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -793,15 +839,20 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             near.setLongitude(longitude);
         }
         int radius = optionsMap.hasKey("radius") ? optionsMap.getInt("radius") : 1000;
-        String[] chains = optionsMap.hasKey("chains") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("chains")) : null;
+        String[] chains = optionsMap.hasKey("chains") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("chains"))
+                : null;
         Map<String, String> chainMetadata = RNRadarUtils.stringStringMap(optionsMap.getMap("chainMetadata"));
-        String[] categories = optionsMap.hasKey("categories") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("categories")) : null;
-        String[] groups = optionsMap.hasKey("groups") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("groups")) : null;
+        String[] categories = optionsMap.hasKey("categories")
+                ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("categories"))
+                : null;
+        String[] groups = optionsMap.hasKey("groups") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("groups"))
+                : null;
         int limit = optionsMap.hasKey("limit") ? optionsMap.getInt("limit") : 10;
 
         Radar.RadarSearchPlacesCallback callback = new Radar.RadarSearchPlacesCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarPlace[] places) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarPlace[] places) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -815,7 +866,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -846,14 +898,16 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             near.setLongitude(longitude);
         }
         int radius = optionsMap.hasKey("radius") ? optionsMap.getInt("radius") : 1000;
-        String[] tags = optionsMap.hasKey("tags") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("tags")) : null;
+        String[] tags = optionsMap.hasKey("tags") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("tags"))
+                : null;
         JSONObject metadata = null;
         if (optionsMap.hasKey("metadata")) {
             try {
                 metadata = RNRadarUtils.jsonForMap(optionsMap.getMap("metadata"));
             } catch (JSONException e) {
                 Log.e(TAG, "JSONException", e);
-                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+                promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                        Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
                 return;
             }
@@ -863,7 +917,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         Radar.RadarSearchGeofencesCallback callback = new Radar.RadarSearchGeofencesCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarGeofence[] geofences) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location,
+                    @Nullable RadarGeofence[] geofences) {
                 if (status == Radar.RadarStatus.SUCCESS) {
                     try {
                         WritableMap map = Arguments.createMap();
@@ -877,7 +932,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -899,7 +955,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         }
 
         if (!optionsMap.hasKey("query") || !optionsMap.hasKey("near")) {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
             return;
         }
@@ -912,12 +969,14 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         near.setLatitude(latitude);
         near.setLongitude(longitude);
         int limit = optionsMap.hasKey("limit") ? optionsMap.getInt("limit") : 10;
-        String country = optionsMap.hasKey("countryCode") ? optionsMap.getString("countryCode") : optionsMap.hasKey("country") ? optionsMap.getString("country") : null;
-        String[] layers = optionsMap.hasKey("layers") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("layers")) : null;
+        String country = optionsMap.hasKey("countryCode") ? optionsMap.getString("countryCode")
+                : optionsMap.hasKey("country") ? optionsMap.getString("country") : null;
+        String[] layers = optionsMap.hasKey("layers") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("layers"))
+                : null;
 
         boolean expandUnits = optionsMap.hasKey("expandUnits") ? optionsMap.getBoolean("expandUnits") : false;
 
-        Radar.autocomplete(query, near, layers, limit, country, expandUnits,new Radar.RadarGeocodeCallback() {
+        Radar.autocomplete(query, near, layers, limit, country, expandUnits, new Radar.RadarGeocodeCallback() {
             @Override
             public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarAddress[] addresses) {
                 if (status == Radar.RadarStatus.SUCCESS) {
@@ -930,7 +989,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -958,7 +1018,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -986,7 +1047,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1026,7 +1088,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1055,7 +1118,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1071,7 +1135,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         }
 
         if (!optionsMap.hasKey("destination")) {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
             return;
         }
@@ -1091,7 +1156,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         Location destination = new Location("RNRadarModule");
         destination.setLatitude(latitude);
         destination.setLongitude(longitude);
-        String[] modesArr = optionsMap.hasKey("modes") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("modes")) : new String[]{};
+        String[] modesArr = optionsMap.hasKey("modes") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("modes"))
+                : new String[] {};
         EnumSet<Radar.RadarRouteMode> modes = EnumSet.noneOf(Radar.RadarRouteMode.class);
         for (String modeStr : modesArr) {
             if (modeStr.equals("FOOT") || modeStr.equals("foot")) {
@@ -1105,7 +1171,9 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             }
         }
         String unitsStr = optionsMap.hasKey("units") ? optionsMap.getString("units") : null;
-        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric")) ? Radar.RadarRouteUnits.METRIC : Radar.RadarRouteUnits.IMPERIAL;
+        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric"))
+                ? Radar.RadarRouteUnits.METRIC
+                : Radar.RadarRouteUnits.IMPERIAL;
 
         Radar.RadarRouteCallback callback = new Radar.RadarRouteCallback() {
             @Override
@@ -1120,7 +1188,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1179,7 +1248,9 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             }
         }
         String unitsStr = optionsMap.hasKey("units") ? optionsMap.getString("units") : null;
-        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric")) ? Radar.RadarRouteUnits.METRIC : Radar.RadarRouteUnits.IMPERIAL;
+        Radar.RadarRouteUnits units = unitsStr != null && (unitsStr.equals("METRIC") || unitsStr.equals("metric"))
+                ? Radar.RadarRouteUnits.METRIC
+                : Radar.RadarRouteUnits.IMPERIAL;
 
         Radar.getMatrix(origins, destinations, mode, units, new Radar.RadarMatrixCallback() {
             @Override
@@ -1194,7 +1265,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                         promise.resolve(map);
                     } catch (JSONException e) {
                         Log.e(TAG, "JSONException", e);
-                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                        promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                                Radar.RadarStatus.ERROR_SERVER.toString());
                     }
                 } else {
                     promise.reject(status.toString(), status.toString());
@@ -1204,13 +1276,14 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
-    public void logConversion(ReadableMap optionsMap, final Promise promise) throws JSONException  {
+    public void logConversion(ReadableMap optionsMap, final Promise promise) throws JSONException {
         if (promise == null) {
             return;
         }
 
         if (!optionsMap.hasKey("name")) {
-            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(), Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
+            promise.reject(Radar.RadarStatus.ERROR_BAD_REQUEST.toString(),
+                    Radar.RadarStatus.ERROR_BAD_REQUEST.toString());
 
             return;
         }
@@ -1218,7 +1291,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         String name = optionsMap.getString("name");
         Double revenue = optionsMap.hasKey("revenue") ? new Double(optionsMap.getDouble("revenue")) : null;
         ReadableMap metadata = optionsMap.hasKey("metadata") ? optionsMap.getMap("metadata") : null;
-        
+
         JSONObject metadataObj = RNRadarUtils.jsonForMap(metadata);
         Radar.RadarLogConversionCallback callback = new Radar.RadarLogConversionCallback() {
             @Override
@@ -1236,7 +1309,8 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
                     }
                 } catch (JSONException e) {
                     Log.e(TAG, "JSONException", e);
-                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(), Radar.RadarStatus.ERROR_SERVER.toString());
+                    promise.reject(Radar.RadarStatus.ERROR_SERVER.toString(),
+                            Radar.RadarStatus.ERROR_SERVER.toString());
                 }
             }
         };

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "radarlabs/radar-sdk-ios" "3.8.8"
+github "radarlabs/radar-sdk-ios" "3.8.9"

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -119,6 +119,10 @@ RCT_EXPORT_METHOD(getUserId:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRe
     resolve([Radar getUserId]);
 }
 
+RCT_EXPORT_METHOD(nativeSdkVersion:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject){
+    resolve([Radar sdkVersion]);
+}
+
 RCT_EXPORT_METHOD(setDescription:(NSString *)description) {
     [Radar setDescription:description];
 }

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -20,7 +20,7 @@ const setUserId = (userId) => {
 };
 
 const getUserId = () => (
-  NativeModules.RNRadar.getUserId()206G
+  NativeModules.RNRadar.getUserId()
 );
 
 const setDescription = (description) => {

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -205,7 +205,6 @@ const nativeSdkVersion = () => (
 
 const rnSdkVersion = () => (version)
 
-
 const Radar = {
   initialize,
   setLogLevel,

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -1,5 +1,5 @@
 import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
-import {version} from '../package.json'
+import { version } from '../package.json'
 
 if (!NativeModules.RNRadar && (Platform.OS === 'ios' || Platform.OS === 'android')) {
   throw new Error('NativeModules.RNRadar is undefined');
@@ -20,7 +20,7 @@ const setUserId = (userId) => {
 };
 
 const getUserId = () => (
-  NativeModules.RNRadar.getUserId()
+  NativeModules.RNRadar.getUserId()206G
 );
 
 const setDescription = (description) => {
@@ -203,7 +203,7 @@ const nativeSdkVersion = () => (
   NativeModules.RNRadar.nativeSdkVersion()
 );
 
-const rnSdkVersion =()=>(version)
+const rnSdkVersion = () => (version)
 
 
 const Radar = {

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -1,4 +1,5 @@
 import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
+import {version} from '../package.json'
 
 if (!NativeModules.RNRadar && (Platform.OS === 'ios' || Platform.OS === 'android')) {
   throw new Error('NativeModules.RNRadar is undefined');
@@ -198,6 +199,13 @@ const off = (event, callback) => {
   }
 };
 
+const nativeSdkVersion = () => (
+  NativeModules.RNRadar.nativeSdkVersion()
+);
+
+const rnSdkVersion =()=>(version)
+
+
 const Radar = {
   initialize,
   setLogLevel,
@@ -244,6 +252,8 @@ const Radar = {
   sendEvent,
   on,
   off,
+  nativeSdkVersion,
+  rnSdkVersion,
 };
 
 export default Radar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.11",
+  "version": "3.8.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.11",
+      "version": "3.8.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.11",
+  "version": "3.8.12",
   "main": "js/index.js",
   "files": [
     "android",

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.8.8"
+  s.dependency "RadarSDK", "~> 3.8.9"
 end


### PR DESCRIPTION
This PR exposes endpoints so that RN SDK can easily access the versioning of the RN SDK and also the underlying native SDK from code.

There are 2 new endpoints:

- `nativeSdkVersion` 
- `rnSdkVersion`

A notable change is that the explicit definition of the versioning of the Android native SDK had been moved from `build.gradle` to `gradle.property`

QA:
we call both of these endpoints in waypoint to determine the versioning of the dependencies 

Android:
<img width="424" alt="image" src="https://github.com/radarlabs/react-native-radar/assets/139801512/3d2d0092-f377-4022-8266-b219c99d993a">
IOS:
<img width="397" alt="image" src="https://github.com/radarlabs/react-native-radar/assets/139801512/f529fbe1-35d2-4f6b-a161-9fa4a569a096">
