### PR TITLE
Start tracking verified ios only

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.8.12'
+        versionName '3.8.12-beta.1'
     }
     lintOptions {
         abortOnError false

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -435,6 +435,11 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
+    public void startTrackingVerified(boolean token) {
+       //not implemented
+    }
+
+    @ReactMethod
     public void startTrackingCustom(ReadableMap optionsMap) {
         try {
             JSONObject optionsObj = RNRadarUtils.jsonForMap(optionsMap);

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "radarlabs/radar-sdk-ios" "3.8.10-beta.1"
+github "radarlabs/radar-sdk-ios" "3.8.9"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "radarlabs/radar-sdk-ios" "3.8.9"
+github "radarlabs/radar-sdk-ios" "3.8.10-beta.1"

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -357,6 +357,10 @@ RCT_EXPORT_METHOD(startTrackingContinuous) {
     [Radar startTrackingWithOptions:RadarTrackingOptions.presetContinuous];
 }
 
+RCT_EXPORT_METHOD(startTrackingVerified:(BOOL)token) {
+    [Radar startTrackingVerified:token];
+}
+
 RCT_EXPORT_METHOD(startTrackingCustom:(NSDictionary *)optionsDict) {
     RadarTrackingOptions *options = [RadarTrackingOptions trackingOptionsFromDictionary:optionsDict];
     [Radar startTrackingWithOptions:options];

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -91,6 +91,12 @@ RCT_EXPORT_MODULE();
     }
 }
 
+- (void)didUpdateToken:(NSString *)token {
+    if(hasListeners){
+       [self sendEventWithName:@"token" body:token]; 
+    }
+}
+
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [Radar initializeWithPublishableKey:publishableKey];
 }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -16,6 +16,7 @@ RCT_EXPORT_MODULE();
     self = [super init];
     if (self) {
         [Radar setDelegate:self];
+        [Radar setVerifiedDelegate:self];
         locationManager = [CLLocationManager new];
         locationManager.delegate = self;
     }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -93,7 +93,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)didUpdateToken:(NSString *)token {
-    if(hasListeners){
+    if(hasListeners) {
        [self sendEventWithName:@"token" body:token]; 
     }
 }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -38,7 +38,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"events", @"location", @"clientLocation", @"error", @"log"];
+    return @[@"events", @"location", @"clientLocation", @"error", @"log", @"token"];
 }
 
 - (void)startObserving {

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -91,6 +91,10 @@ const startTrackingCustom = options => (
   NativeModules.RNRadar.startTrackingCustom(options)
 );
 
+const startTrackingVerified = token => (
+  NativeModules.RNRadar.startTrackingVerified(token)
+);
+
 const mockTracking = options => (
   NativeModules.RNRadar.mockTracking(options)
 );
@@ -222,6 +226,7 @@ const Radar = {
   trackOnce,
   trackVerified,
   trackVerifiedToken,
+  startTrackingVerified,
   startTrackingEfficient,
   startTrackingResponsive,
   startTrackingContinuous,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.12",
+  "version": "3.8.12-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.12",
+      "version": "3.8.12-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.12",
+  "version": "3.8.12-beta.1",
   "main": "js/index.js",
   "files": [
     "android",

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.8.9"
+  s.dependency "RadarSDK", "~> 3.8.10-beta.1"
 end

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.8.10-beta.1"
+  s.dependency "RadarSDK", "~> 3.8.9"
 end


### PR DESCRIPTION
This PR implements the RN bridge for startTrackingVerified and the event listener for the 'token' event.

QA in Waypoint:
![image](https://github.com/radarlabs/react-native-radar/assets/139801512/c17c497e-9a8f-425a-80ea-4fcda53f154c)
We can successfully get back a token from the server, which then can be successfully decoded 