### PR TITLE
Wrapper for setAndroidNotificationOptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.8.14'
+        versionName '3.8.15'
     }
     lintOptions {
         abortOnError false
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.15'
+    api 'io.radar:sdk:3.8.16'
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -34,7 +34,7 @@ import io.radar.sdk.model.RadarRouteMatrix;
 import io.radar.sdk.model.RadarRoutes;
 import io.radar.sdk.model.RadarTrip;
 import io.radar.sdk.model.RadarUser;
-import io.radar.sdk.RadarNotificationsOptions;
+import io.radar.sdk.RadarNotificationOptions;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -529,11 +529,11 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
-    public void setAndroidNotificationsOptions(ReadableMap optionsMap) {
+    public void setAndroidNotificationOptions(ReadableMap optionsMap) {
         try {
             JSONObject optionsObj = RNRadarUtils.jsonForMap(optionsMap);
-            RadarNotificationsOptions options = RadarNotificationsOptions.fromJson(optionsObj);
-            Radar.setNotificationsOptions(options);
+            RadarNotificationOptions options = RadarNotificationOptions.fromJson(optionsObj);
+            Radar.setNotificationOptions(options);
         } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
         }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -1275,3 +1275,5 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
 }
+
+

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -529,7 +529,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
-    public void setAndroidNotificationOptions(ReadableMap optionsMap) {
+    public void setNotificationOptions(ReadableMap optionsMap) {
         try {
             JSONObject optionsObj = RNRadarUtils.jsonForMap(optionsMap);
             RadarNotificationOptions options = RadarNotificationOptions.fromJson(optionsObj);

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -1275,5 +1275,3 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
 }
-
-

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -34,6 +34,7 @@ import io.radar.sdk.model.RadarRouteMatrix;
 import io.radar.sdk.model.RadarRoutes;
 import io.radar.sdk.model.RadarTrip;
 import io.radar.sdk.model.RadarUser;
+import io.radar.sdk.RadarNotificationsOptions;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -522,6 +523,17 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             JSONObject optionsObj = RNRadarUtils.jsonForMap(optionsMap);
             RadarTrackingOptionsForegroundService options = RadarTrackingOptionsForegroundService.fromJson(optionsObj);
             Radar.setForegroundServiceOptions(options);
+        } catch (JSONException e) {
+            Log.e(TAG, "JSONException", e);
+        }
+    }
+
+    @ReactMethod
+    public void setAndroidNotificationsOptions(ReadableMap optionsMap) {
+        try {
+            JSONObject optionsObj = RNRadarUtils.jsonForMap(optionsMap);
+            RadarNotificationsOptions options = RadarNotificationsOptions.fromJson(optionsObj);
+            Radar.setNotificationsOptions(options);
         } catch (JSONException e) {
             Log.e(TAG, "JSONException", e);
         }

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -429,7 +429,7 @@ RCT_EXPORT_METHOD(setForegroundServiceOptions:(NSDictionary *)optionsDict) {
     // not implemented
 }
 
-RCT_EXPORT_METHOD(setAndroidNotificationsOptions:(NSDictionary *)optionsDict) {
+RCT_EXPORT_METHOD(setAndroidNotificationOptions:(NSDictionary *)optionsDict) {
     // not implemented
 }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -429,7 +429,7 @@ RCT_EXPORT_METHOD(setForegroundServiceOptions:(NSDictionary *)optionsDict) {
     // not implemented
 }
 
-RCT_EXPORT_METHOD(setAndroidNotificationOptions:(NSDictionary *)optionsDict) {
+RCT_EXPORT_METHOD(setNotificationOptions:(NSDictionary *)optionsDict) {
     // not implemented
 }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -425,7 +425,11 @@ RCT_EXPORT_METHOD(getTrackingOptions:(RCTPromiseResolveBlock)resolve reject:(RCT
     resolve([options dictionaryValue]);
 }
 
-RCT_EXPORT_METHOD(setForegroundServiceOptions) {
+RCT_EXPORT_METHOD(setForegroundServiceOptions:(NSDictionary *)optionsDict) {
+    // not implemented
+}
+
+RCT_EXPORT_METHOD(setAndroidNotificationsOptions:(NSDictionary *)optionsDict) {
     // not implemented
 }
 

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -115,8 +115,8 @@ const setForegroundServiceOptions = options => (
   NativeModules.RNRadar.setForegroundServiceOptions(options)
 );
 
-const setAndroidNotificationOptions = options => (
-  NativeModules.RNRadar.setAndroidNotificationOptions(options)
+const setNotificationOptions = options => (
+  NativeModules.RNRadar.setNotificationOptions(options)
 );
 
 const getTripOptions = () => (
@@ -235,7 +235,7 @@ const Radar = {
   isTracking,
   getTrackingOptions,
   setForegroundServiceOptions,
-  setAndroidNotificationOptions,
+  setNotificationOptions,
   acceptEvent,
   rejectEvent,
   getTripOptions,

--- a/js/index.native.js
+++ b/js/index.native.js
@@ -115,6 +115,10 @@ const setForegroundServiceOptions = options => (
   NativeModules.RNRadar.setForegroundServiceOptions(options)
 );
 
+const setAndroidNotificationOptions = options => (
+  NativeModules.RNRadar.setAndroidNotificationOptions(options)
+);
+
 const getTripOptions = () => (
   NativeModules.RNRadar.getTripOptions()
 )
@@ -231,6 +235,7 @@ const Radar = {
   isTracking,
   getTrackingOptions,
   setForegroundServiceOptions,
+  setAndroidNotificationOptions,
   acceptEvent,
   rejectEvent,
   getTripOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.14",
+  "version": "3.8.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.14",
+      "version": "3.8.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.14",
+  "version": "3.8.15",
   "main": "js/index.js",
   "files": [
     "android",


### PR DESCRIPTION
- Wrapper for setAndroidNotification settings
- Bump version
- IOS wrapper for `setForegroundOptions` and `setAndroidNotificationOptions` now takes a dictionary such that they are truly no-ops rather than crashing upon called on ios.