### PR TITLE
expandUnits -> mailable

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.8.19'
+        versionName '3.9.0'
     }
     lintOptions {
         abortOnError false
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.8.18'
+    api 'io.radar:sdk:3.9.0'
 }

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -943,7 +943,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         boolean mailable = optionsMap.hasKey("mailable") ? optionsMap.getBoolean("mailable") : false;
 
-        Radar.autocomplete(query, near, layers, limit, country, mailable = mailable, new Radar.RadarGeocodeCallback() {
+        Radar.autocomplete(query, near, layers, limit, country, true, mailable, new Radar.RadarGeocodeCallback() {
             @Override
             public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarAddress[] addresses) {
                 if (status == Radar.RadarStatus.SUCCESS) {

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -943,7 +943,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
 
         boolean mailable = optionsMap.hasKey("mailable") ? optionsMap.getBoolean("mailable") : false;
 
-        Radar.autocomplete(query, near, layers, limit, country, mailable, new Radar.RadarGeocodeCallback() {
+        Radar.autocomplete(query, near, layers, limit, country, mailable = mailable, new Radar.RadarGeocodeCallback() {
             @Override
             public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarAddress[] addresses) {
                 if (status == Radar.RadarStatus.SUCCESS) {

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -941,9 +941,9 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         String country = optionsMap.hasKey("countryCode") ? optionsMap.getString("countryCode") : optionsMap.hasKey("country") ? optionsMap.getString("country") : null;
         String[] layers = optionsMap.hasKey("layers") ? RNRadarUtils.stringArrayForArray(optionsMap.getArray("layers")) : null;
 
-        boolean expandUnits = optionsMap.hasKey("expandUnits") ? optionsMap.getBoolean("expandUnits") : false;
+        boolean mailable = optionsMap.hasKey("mailable") ? optionsMap.getBoolean("mailable") : false;
 
-        Radar.autocomplete(query, near, layers, limit, country, expandUnits,new Radar.RadarGeocodeCallback() {
+        Radar.autocomplete(query, near, layers, limit, country, mailable, new Radar.RadarGeocodeCallback() {
             @Override
             public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarAddress[] addresses) {
                 if (status == Radar.RadarStatus.SUCCESS) {

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "radarlabs/radar-sdk-ios" "3.8.13"
+github "radarlabs/radar-sdk-ios" "3.9.0"

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -795,16 +795,16 @@ RCT_EXPORT_METHOD(autocomplete:(NSDictionary *)optionsDict resolve:(RCTPromiseRe
         country = optionsDict[@"country"];
     }
 
-    BOOL expandUnits = false;
-    NSNumber *expandUnitsNumber = optionsDict[@"expandUnits"];
-    if (expandUnitsNumber != nil && [expandUnitsNumber isKindOfClass:[NSNumber class]]) {
-        expandUnits = [expandUnitsNumber boolValue]; 
+    BOOL mailable = false;
+    NSNumber *mailableNumber = optionsDict[@"mailable"];
+    if (mailableNumber != nil && [mailableNumber isKindOfClass:[NSNumber class]]) {
+        mailable = [mailableNumber boolValue]; 
     }
 
     __block RCTPromiseResolveBlock resolver = resolve;
     __block RCTPromiseRejectBlock rejecter = reject;
 
-    [Radar autocompleteQuery:query near:near layers:layers limit:limit country:country expandUnits:expandUnits completionHandler:^(RadarStatus status, NSArray<RadarAddress *> * _Nullable addresses) {
+    [Radar autocompleteQuery:query near:near layers:layers limit:limit country:country mailable:mailable completionHandler:^(RadarStatus status, NSArray<RadarAddress *> * _Nullable addresses) {
         if (status == RadarStatusSuccess && resolver) {
             NSMutableDictionary *dict = [NSMutableDictionary new];
             [dict setObject:[Radar stringForStatus:status] forKey:@"status"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.8.19",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.8.19",
+      "version": "3.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.8.19",
+  "version": "3.9.0",
   "main": "js/index.js",
   "files": [
     "android",

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.8.13"
+  s.dependency "RadarSDK", "~> 3.9.0"
 end

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -373,7 +373,7 @@ describe('calls native implementation', () => {
       },
       limit: 10,
       countryCode: "US",
-      expandUnits: true
+      mailable: true
     };
     Radar.autocomplete(options);
 


### PR DESCRIPTION
This PR changes the `expandUnits` param for autocomplete to `mailable`. Value of `true` is passed in for Android wrapper since there are no default value params in Java. Verified by testing using Waypoint