### PR TITLE
add a ci typing step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
             npm run test
           environment:
             JEST_JUNIT_OUTPUT: test-results/jest/junit.xml
+      - run:
+        name: Type-check
+        command: npx tsc --noEmit
       - persist_to_workspace:
           root: ~/react-native-radar
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT: test-results/jest/junit.xml
       - run:
-        name: Type-check
-        command: npx tsc --noEmit
+          name: Type-check
+          command: npx tsc --noEmit
       - persist_to_workspace:
           root: ~/react-native-radar
           paths:


### PR DESCRIPTION
QA: CI is correctly flagging the wrong type that is in master right now. https://app.circleci.com/pipelines/github/radarlabs/react-native-radar/1430/workflows/dd445600-b65c-4b97-9819-e8e6c099524a/jobs/3997
