### PR TITLE
Typing fixes

### DIFF
--- a/src/@types/RadarNativeInterface.ts
+++ b/src/@types/RadarNativeInterface.ts
@@ -37,7 +37,7 @@ import {
 } from "./types";
 
 export interface RadarNativeInterface {
-  initialize: (publishableKey: string, fraud: boolean) => void;
+  initialize: (publishableKey: string, fraud?: boolean) => void;
   setLogLevel: (level: RadarLogLevel) => void;
   setUserId: (userId: string) => void;
   getUserId: () => Promise<string>;

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -584,6 +584,8 @@ export interface RadarTrackingOptionsForegroundService {
   importance?: number;
   id?: number;
   channelName?: string;
+  iconString?: string;
+  iconColor?: string;
 }
 
 export type RadarTripStatus =

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -47,6 +47,7 @@ if (
 }
 
 const eventEmitter = new NativeEventEmitter(NativeModules.RNRadar);
+
 const initialize = (publishableKey: string, fraud: boolean = false): void => {
   NativeModules.RNRadar.initialize(publishableKey, fraud);
 };


### PR DESCRIPTION
- Make `Radar.initialize` have optional second param.
- Add `iconString` and `iconColor` fields to `RadarTrackingOptionsForegroundService`