### PR TITLE
Bump to 3.10.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.4-beta.2'
+        versionName '3.10.4'
     }
     lintOptions {
         abortOnError false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.3'
+        versionName '3.10.4'
     }
     lintOptions {
         abortOnError false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.4'
+        versionName '3.10.4-beta.2'
     }
     lintOptions {
         abortOnError false

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -105,7 +105,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         }
         SharedPreferences sharedPref = reactContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPref.edit();
-        editor.putString("x_platform_sdk_version", "3.10.4-beta.2");
+        editor.putString("x_platform_sdk_version", "3.10.4");
         editor.apply();
     }
 

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -42,6 +42,8 @@ import org.json.JSONObject;
 
 import java.util.EnumSet;
 import java.util.Map;
+import android.content.SharedPreferences;
+import android.content.Context;
 
 public class RNRadarModule extends ReactContextBaseJavaModule implements PermissionListener {
 
@@ -53,11 +55,14 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     private RNRadarVerifiedReceiver verifiedReceiver;    
     private int listenerCount = 0;
     private boolean fraud = false;
+    private final ReactApplicationContext reactContext;
+    
 
     public RNRadarModule(ReactApplicationContext reactContext) {
         super(reactContext);
         receiver = new RNRadarReceiver();
         verifiedReceiver = new RNRadarVerifiedReceiver();
+        this.reactContext = reactContext;
     }
 
     @ReactMethod
@@ -98,6 +103,10 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
             Radar.initialize(getReactApplicationContext(), publishableKey);
             Radar.setReceiver(receiver);
         }
+        SharedPreferences sharedPref = reactContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putString("x_platform_sdk_version", "3.10.4");
+        editor.apply();
     }
 
     @ReactMethod

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -105,7 +105,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         }
         SharedPreferences sharedPref = reactContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPref.edit();
-        editor.putString("x_platform_sdk_version", "3.10.4");
+        editor.putString("x_platform_sdk_version", "3.10.4-beta.2");
         editor.apply();
     }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -99,7 +99,8 @@ RCT_EXPORT_MODULE();
 }
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
-    [Radar initializeWithPublishableKey:publishableKey];
+    [Radar initializeWithPublishableKey:publishableKey]; 
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.4" forKey:@"radar-xPlatformSDKVersion"];
 }
 
 RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -100,7 +100,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [Radar initializeWithPublishableKey:publishableKey]; 
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.4-beta.2" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.4" forKey:@"radar-xPlatformSDKVersion"];
 }
 
 RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -100,7 +100,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [Radar initializeWithPublishableKey:publishableKey]; 
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.4" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.4-beta.2" forKey:@"radar-xPlatformSDKVersion"];
 }
 
 RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.4-beta.2",
+  "version": "3.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.4-beta.2",
+      "version": "3.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.3",
+      "version": "3.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.4",
+  "version": "3.10.4-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.4",
+      "version": "3.10.4-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.4-beta.2",
+  "version": "3.10.4",
   "main": "dist/src/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.4",
+  "version": "3.10.4-beta.2",
   "main": "dist/src/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "main": "dist/src/index.js",
   "files": [
     "android",


### PR DESCRIPTION
Since we are newly setting the x-platform version on native I cut waypoint builds as sanity checks.
ios: https://expo.dev/accounts/radarlabs/projects/waypoint/builds/8a96b35c-7aca-4977-8735-c369f7bafafe
android:https://expo.dev/accounts/radarlabs/projects/waypoint/builds/d799def8-62d8-4f10-9079-04d9db80617a