### PR TITLE
Fix for JS projects

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.7-beta.2'
+        versionName '3.10.8'
     }
     lintOptions {
         abortOnError false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.7-beta.1'
+        versionName '3.10.7-beta.2'
     }
     lintOptions {
         abortOnError false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.6'
+        versionName '3.10.7-beta.1'
     }
     lintOptions {
         abortOnError false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.10.8'
+        versionName '3.10.7'
     }
     lintOptions {
         abortOnError false

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -95,7 +95,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.10.7-beta.1");
+        editor.putString("x_platform_sdk_version", "3.10.7-beta.2");
         editor.apply();
         if (fraud) {
             Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud);

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -95,7 +95,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.10.7-beta.2");
+        editor.putString("x_platform_sdk_version", "3.10.8");
         editor.apply();
         if (fraud) {
             Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud);

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -95,7 +95,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.10.6");
+        editor.putString("x_platform_sdk_version", "3.10.7-beta.1");
         editor.apply();
         if (fraud) {
             Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud);

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -95,7 +95,7 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.10.8");
+        editor.putString("x_platform_sdk_version", "3.10.7");
         editor.apply();
         if (fraud) {
             Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud);

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -100,7 +100,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.6" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.7-beta.1" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
 }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -100,7 +100,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.7-beta.2" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.8" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
 }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -100,7 +100,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.7-beta.1" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.7-beta.2" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
 }
 

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -100,7 +100,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.8" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.10.7" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.6",
+  "version": "3.10.7-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.6",
+      "version": "3.10.7-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.8",
+  "version": "3.10.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.8",
+      "version": "3.10.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.7-beta.1",
+  "version": "3.10.7-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.7-beta.1",
+      "version": "3.10.7-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.10.7-beta.2",
+  "version": "3.10.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.10.7-beta.2",
+      "version": "3.10.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.8",
+  "version": "3.10.7",
   "main": "dist/src/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.7-beta.2",
+  "version": "3.10.8",
   "main": "dist/src/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.7-beta.1",
+  "version": "3.10.7-beta.2",
   "main": "dist/src/index.js",
   "files": [
     "android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.10.6",
+  "version": "3.10.7-beta.1",
   "main": "dist/src/index.js",
   "files": [
     "android",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { RadarNativeInterface } from "./@types/RadarNativeInterface";
-import {Platform} from "react-native";
+import { Platform } from "react-native";
 
 let module: RadarNativeInterface;
 
@@ -7,13 +7,16 @@ module = require("./index.native").default;
 
 export default module;
 
-let RadarRNWeb =  Platform.OS === 'web'?  require("./index.web").default: {};
+let RadarRNWeb = Platform.OS === "web" ? require("./index.web").default : {};
 
 export { RadarRNWeb };
 
-export { default as Autocomplete } from "./ui/autocomplete";
-export { default as Map } from "./ui/map";
+let Autocomplete =
+  Platform.OS !== "web" ? require("./ui/autocomplete").default : {};
+export { Autocomplete };
 
+let Map = Platform.OS !== "web" ? require("./ui/map").default : {};
+export { Map };
 
 export * from "./@types/types";
 export * from "./@types/RadarNativeInterface";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { RadarNativeInterface } from "./@types/RadarNativeInterface";
+import {Platform} from "react-native";
 
 let module: RadarNativeInterface;
 
@@ -6,7 +7,10 @@ module = require("./index.native").default;
 
 export default module;
 
-export { default as RadarRNWeb } from "./index.web";
+let RadarRNWeb =  Platform.OS === 'web'?  require("./index.web").default: {};
+
+export { RadarRNWeb };
+
 export { default as Autocomplete } from "./ui/autocomplete";
 export { default as Map } from "./ui/map";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
     },
     "include": [
       "src/index.ts",
-      "src/index.web.js"
+      "src/index.web.js",
+      "src/ui"
     ],
     "exclude": [
       "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       "noImplicitAny": false,
     },
     "include": [
-      "src/index.ts"
+      "src/index.ts",
+      "src/index.web.js"
     ],
     "exclude": [
       "node_modules",


### PR DESCRIPTION
The previous upgrade to TS introduced a bug that affected projects on older versions of expo using JS. It appears that just loading the import of `radar-js-sdk` into the js layer was causing issues. This PR introduces a fix to prevent that from occuring.