### PR TITLE
add addRadarSDKVerify option

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'io.radar:sdk:3.18.6'
+    api 'org.nanohttpd:nanohttpd:2.3.1'
+    api 'io.radar:sdk:3.18.8-beta.1'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,5 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'org.nanohttpd:nanohttpd:2.3.1'
     api 'io.radar:sdk:3.18.8-beta.1'
 }
-

--- a/android/src/main/java/io/radar/react/RNRadarModule.java
+++ b/android/src/main/java/io/radar/react/RNRadarModule.java
@@ -449,6 +449,16 @@ public class RNRadarModule extends ReactContextBaseJavaModule implements Permiss
     }
 
     @ReactMethod
+    public void startVerifyServer() {
+        Radar.startVerifyServer();
+    }
+
+    @ReactMethod
+    public void stopVerifyServer() {
+        Radar.stopVerifyServer();
+    }
+
+    @ReactMethod
     public void startTrackingEfficient() {
         Radar.startTracking(RadarTrackingOptions.EFFICIENT);
     }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -565,6 +565,20 @@ export default function App() {
           />
 
           <ExampleButton
+            title="startVerifyServer"
+            onPress={() => {
+              Radar.startVerifyServer();
+            }}
+          />
+
+          <ExampleButton
+            title="stopVerifyServer"
+            onPress={() => {
+              Radar.stopVerifyServer();
+            }}
+          />
+
+          <ExampleButton
             title="version"
             onPress={() => {
               Radar.nativeSdkVersion().then((nativeVersion) => {

--- a/example/app.json
+++ b/example/app.json
@@ -38,7 +38,7 @@
           "androidFraud": true,
           "androidBackgroundPermission": true,
           "androidFineLocationPermission": true,
-          "addRadarSDKMotion": true,
+          "addRadarSDKMotion": false,
           "addRadarSDKVerify": true
         }
       ],

--- a/example/app.json
+++ b/example/app.json
@@ -16,7 +16,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.radar.example",
+      "bundleIdentifier": "com.radar.example"
     },
     "android": {
       "adaptiveIcon": {
@@ -38,7 +38,8 @@
           "androidFraud": true,
           "androidBackgroundPermission": true,
           "androidFineLocationPermission": true,
-          "addRadarSDKMotion": true
+          "addRadarSDKMotion": true,
+          "addRadarSDKVerify": true
         }
       ],
       [

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12203,8 +12203,9 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.18.3",
+      "version": "3.19.0-beta.1",
       "resolved": "file:..",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "@react-native-community/netinfo": "^7.1.3",
@@ -23201,7 +23202,7 @@
       }
     },
     "react-native-radar": {
-      "version": "3.18.3",
+      "version": "3.19.0-beta.1",
       "requires": {
         "@babel/runtime": "^7.21.0",
         "@react-native-community/netinfo": "^7.1.3",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -26,7 +26,7 @@
       }
     },
     "..": {
-      "version": "3.18.3",
+      "version": "3.19.0-beta.1",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5273,6 +5273,7 @@
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-7.1.12.tgz",
       "integrity": "sha512-fkCRkOgzfdD0sr8JTasDgm716l8bJPkCNjXIyllG8K+UyixVa68lroQmgW9pewE5G5p43I9MWPtGZR/kVowBzg==",
+      "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.59"
       }
@@ -12046,7 +12047,8 @@
     "node_modules/radar-sdk-js": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg=="
+      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
+      "license": "Apache-2.0"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,6 @@
     },
     "..": {
       "version": "3.19.0-beta.1",
-      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -5267,15 +5266,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/netinfo": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-7.1.12.tgz",
-      "integrity": "sha512-fkCRkOgzfdD0sr8JTasDgm716l8bJPkCNjXIyllG8K+UyixVa68lroQmgW9pewE5G5p43I9MWPtGZR/kVowBzg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -12044,12 +12034,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "node_modules/radar-sdk-js": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -12205,28 +12189,8 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.19.0-beta.1",
-      "resolved": "file:..",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@react-native-community/netinfo": "^7.1.3",
-        "radar-sdk-js": "^3.7.1"
-      },
-      "peerDependencies": {
-        "@maplibre/maplibre-react-native": ">=9.0.1 || >=10.0.0-alpha",
-        "expo": ">=43.0.5",
-        "react": ">= 16.8.6",
-        "react-native": ">= 0.60.0"
-      },
-      "peerDependenciesMeta": {
-        "@maplibre/maplibre-react-native": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        }
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/react-native-web": {
       "version": "0.19.13",
@@ -18070,12 +18034,6 @@
         "joi": "^17.2.1"
       }
     },
-    "@react-native-community/netinfo": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-7.1.12.tgz",
-      "integrity": "sha512-fkCRkOgzfdD0sr8JTasDgm716l8bJPkCNjXIyllG8K+UyixVa68lroQmgW9pewE5G5p43I9MWPtGZR/kVowBzg==",
-      "requires": {}
-    },
     "@react-native/assets-registry": {
       "version": "0.74.87",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.87.tgz",
@@ -23015,11 +22973,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "radar-sdk-js": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg=="
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -23204,11 +23157,35 @@
       }
     },
     "react-native-radar": {
-      "version": "3.19.0-beta.1",
+      "version": "file:..",
       "requires": {
+        "@babel/core": "^7.2.2",
+        "@babel/preset-env": "^7.2.3",
+        "@babel/preset-react": "^7.0.0",
+        "@babel/register": "^7.0.0",
         "@babel/runtime": "^7.21.0",
         "@react-native-community/netinfo": "^7.1.3",
-        "radar-sdk-js": "^3.7.1"
+        "babel-core": "^7.0.0-bridge.0",
+        "babel-eslint": "^10.0.1",
+        "babel-jest": "^23.4.2",
+        "braces": ">=2.3.2",
+        "eslint": "^5.6.1",
+        "eslint-config-airbnb": "^17.1.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-jest": "^22.1.2",
+        "eslint-plugin-jsx-a11y": "^6.1.1",
+        "eslint-plugin-react": "^7.11.1",
+        "expo": "^51.0.0",
+        "expo-module-scripts": "^3.5.2",
+        "jest": "^29.7.0",
+        "jest-junit": "^16.0.0",
+        "logkitty": ">=0.7.1",
+        "metro-react-native-babel-preset": "^0.51.1",
+        "npm-run-all": "^4.1.5",
+        "radar-sdk-js": "^3.7.1",
+        "react": "^18.2.0",
+        "react-native": "^0.74.5",
+        "typescript": "^5.3.3"
       }
     },
     "react-native-web": {

--- a/ios/RNRadar.m
+++ b/ios/RNRadar.m
@@ -357,6 +357,14 @@ RCT_EXPORT_METHOD(getVerifiedLocationToken:(RCTPromiseResolveBlock)resolve rejec
     [Radar getVerifiedLocationToken:completionHandler];
 }
 
+RCT_EXPORT_METHOD(startVerifyServer) {
+    [Radar startVerifyServer];
+}
+
+RCT_EXPORT_METHOD(stopVerifyServer) {
+    [Radar stopVerifyServer];
+}
+
 RCT_EXPORT_METHOD(startTrackingEfficient) {
     [Radar startTrackingWithOptions:RadarTrackingOptions.presetEfficient];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.19.0-beta.1",
+  "version": "3.19.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.19.0-beta.1",
+      "version": "3.19.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.18.5",
+  "version": "3.19.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.18.5",
+      "version": "3.19.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.19.0-beta.1",
+  "version": "3.19.0-beta.2",
   "main": "dist/index.js",
   "files": [
     "/android",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.18.5",
+  "version": "3.19.0-beta.1",
   "main": "dist/index.js",
   "files": [
     "/android",

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -8,4 +8,5 @@ export interface RadarPluginProps {
     androidFineLocationPermission?: boolean;
     addRadarSDKMotion?: boolean;
     iosNSMotionUsageDescription?: string;
+    addRadarSDKVerify?: boolean;
   }

--- a/plugin/src/withRadarAndroid.ts
+++ b/plugin/src/withRadarAndroid.ts
@@ -59,6 +59,7 @@ export const withRadarAndroid = (
           <!-- for React Native -->
           <domain-config cleartextTrafficPermitted="true">
               <domain includeSubdomains="true">localhost</domain>
+              <domain includeSubdomains="true">10.0.2.2</domain>
           </domain-config>
       
           <!-- for SSL pinning -->

--- a/plugin/src/withRadarAndroid.ts
+++ b/plugin/src/withRadarAndroid.ts
@@ -83,7 +83,8 @@ export const withRadarAndroid = (
     if (config.modResults.language === "groovy") {
       config.modResults.contents = modifyAppBuildGradle(
         config.modResults.contents,
-        args.androidFraud ?? false
+        args.androidFraud ?? false,
+        args.addRadarSDKVerify ?? false
       );
     } else {
       throw new Error(
@@ -151,9 +152,10 @@ async function setCustomConfigAsync(
   return androidManifest;
 }
 
-function modifyAppBuildGradle(buildGradle: string, androidFraud: boolean) {
+function modifyAppBuildGradle(buildGradle: string, androidFraud: boolean, addRadarSDKVerify: boolean) {
   let hasLocationService = false;
   let hasPlayIntegrity = false;
+  let hasNanoHTTPD = false;
   if (
     buildGradle.includes(
       'com.google.android.gms:play-services-location:21.0.1"'
@@ -164,6 +166,10 @@ function modifyAppBuildGradle(buildGradle: string, androidFraud: boolean) {
 
   if (buildGradle.includes('com.google.android.play:integrity:1.2.0"')) {
     hasPlayIntegrity = true;
+  }
+
+  if (buildGradle.includes('org.nanohttpd:nanohttpd:2.3.1"')) {
+    hasNanoHTTPD = true;
   }
 
   const pattern = /^dependencies {/m;
@@ -184,6 +190,10 @@ function modifyAppBuildGradle(buildGradle: string, androidFraud: boolean) {
   if (androidFraud && !hasPlayIntegrity) {
     replacementString +=
       "\n\n" + '    implementation "com.google.android.play:integrity:1.2.0"';
+  }
+  if (addRadarSDKVerify && !hasNanoHTTPD) {
+    replacementString +=
+      "\n\n" + '    implementation "org.nanohttpd:nanohttpd:2.3.1"';
   }
 
   return buildGradle.replace(

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -15,7 +15,6 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
     if (args.iosBackgroundMode) {
       config.modResults.UIBackgroundModes = ["location", "fetch"];
     }
-    /*
     if (args.iosFraud) {
       config.modResults.NSAppTransportSecurity = {
         NSAllowsArbitraryLoads: false,
@@ -36,7 +35,6 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
         },
       };
     }
-      */
     if (args.addRadarSDKMotion) {
       config.modResults.NSMotionUsageDescription =
         args.iosNSMotionUsageDescription ??

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -82,7 +82,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
         const contents = await fs.readFile(filePath, 'utf-8');
 
         // Check if the pod declaration already exists
-        if (contents.indexOf("pod 'Telegraph', '0.40.0'") === -1) {
+        if (contents.indexOf("pod 'Telegraph', '0.30.0'") === -1) {
           // Find the target block
           const targetRegex = /target '(\w+)' do/g;
           const match = targetRegex.exec(contents);
@@ -92,7 +92,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
 
             // Insert the pod declaration within the target block
             const targetBlock = contents.substring(targetStartIndex, targetEndIndex);
-            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'Telegraph', '0.30.0'`);
+            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'Telegraph', '0.30.0', :modular_headers => true\n  pod 'CocoaAsyncSocket', :modular_headers => true\n  pod 'HTTPParserC', :modular_headers => true`);
             const newContents = contents.replace(targetBlock, updatedTargetBlock);
 
             // Write the updated contents back to the Podfile

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -82,7 +82,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
         const contents = await fs.readFile(filePath, 'utf-8');
 
         // Check if the pod declaration already exists
-        if (contents.indexOf("pod 'RadarSDK/Verify', '3.19.2-beta.8'") === -1) {
+        if (contents.indexOf("pod 'RadarSDK/Verify', '3.19.2-beta.9'") === -1) {
           // Find the target block
           const targetRegex = /target '(\w+)' do/g;
           const match = targetRegex.exec(contents);
@@ -92,7 +92,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
 
             // Insert the pod declaration within the target block
             const targetBlock = contents.substring(targetStartIndex, targetEndIndex);
-            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'RadarSDK/Verify', '3.19.2-beta.8'`);
+            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'RadarSDK/Verify', '3.19.2-beta.9'\n    pod 'CocoaAsyncSocket', :modular_headers => true\n  pod 'HTTPParserC', :modular_headers => true`);
             const newContents = contents.replace(targetBlock, updatedTargetBlock);
 
             // Write the updated contents back to the Podfile

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -82,7 +82,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
         const contents = await fs.readFile(filePath, 'utf-8');
 
         // Check if the pod declaration already exists
-        if (contents.indexOf("pod 'Telegraph', '0.30.0'") === -1) {
+        if (contents.indexOf("pod 'RadarSDK/Verify', '3.19.2-beta.8'") === -1) {
           // Find the target block
           const targetRegex = /target '(\w+)' do/g;
           const match = targetRegex.exec(contents);
@@ -92,7 +92,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
 
             // Insert the pod declaration within the target block
             const targetBlock = contents.substring(targetStartIndex, targetEndIndex);
-            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'Telegraph', '0.30.0', :modular_headers => true\n  pod 'CocoaAsyncSocket', :modular_headers => true\n  pod 'HTTPParserC', :modular_headers => true`);
+            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'RadarSDK/Verify', '3.19.2-beta.8'`);
             const newContents = contents.replace(targetBlock, updatedTargetBlock);
 
             // Write the updated contents back to the Podfile

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -74,6 +74,36 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
       },
     ]);
   }
+  if (args.addRadarSDKVerify) {
+    config = withDangerousMod(config, [
+      'ios',
+      async config => {
+        const filePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+        const contents = await fs.readFile(filePath, 'utf-8');
+
+        // Check if the pod declaration already exists
+        if (contents.indexOf("pod 'Telegraph', '0.40.0'") === -1) {
+          // Find the target block
+          const targetRegex = /target '(\w+)' do/g;
+          const match = targetRegex.exec(contents);
+          if (match) {
+            const targetStartIndex = match.index;
+            const targetEndIndex = contents.indexOf('end', targetStartIndex) + 3;
+
+            // Insert the pod declaration within the target block
+            const targetBlock = contents.substring(targetStartIndex, targetEndIndex);
+            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'Telegraph', '0.40.0'`);
+            const newContents = contents.replace(targetBlock, updatedTargetBlock);
+
+            // Write the updated contents back to the Podfile
+            await fs.writeFile(filePath, newContents);
+          }
+        }
+
+        return config;
+      },
+    ]);
+  }
 
   return config;
 };

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -92,7 +92,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
 
             // Insert the pod declaration within the target block
             const targetBlock = contents.substring(targetStartIndex, targetEndIndex);
-            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'Telegraph', '0.40.0'`);
+            const updatedTargetBlock = targetBlock.replace(/(target '(\w+)' do)/, `$1\n  pod 'Telegraph', '0.30.0'`);
             const newContents = contents.replace(targetBlock, updatedTargetBlock);
 
             // Write the updated contents back to the Podfile

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -15,6 +15,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
     if (args.iosBackgroundMode) {
       config.modResults.UIBackgroundModes = ["location", "fetch"];
     }
+    /*
     if (args.iosFraud) {
       config.modResults.NSAppTransportSecurity = {
         NSAllowsArbitraryLoads: false,
@@ -35,6 +36,7 @@ export const withRadarIOS: ConfigPlugin<RadarPluginProps> = (config, args) => {
         },
       };
     }
+      */
     if (args.addRadarSDKMotion) {
       config.modResults.NSMotionUsageDescription =
         args.iosNSMotionUsageDescription ??

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.summary = package[:description]
   s.source = { git: package[:repository][:url] }
   s.source_files = "ios/*.{h,m}"
-  s.platform = :ios, "10.0"
+  s.platform = :ios, "12.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.19.2-beta.1"
+  s.dependency "RadarSDK", "~> 3.19.2-beta.4"
 end

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "12.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.19.2-beta.6"
+  s.dependency "RadarSDK", "~> 3.19.2-beta.7"
 end

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "12.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.19.2-beta.4"
+  s.dependency "RadarSDK", "~> 3.19.2-beta.6"
 end

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "12.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.19.2-beta.7"
+  s.dependency "RadarSDK", "~> 3.19.2-beta.9"
 end

--- a/react-native-radar.podspec
+++ b/react-native-radar.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
 
   s.dependency "React"
-  s.dependency "RadarSDK", "~> 3.18.5"
+  s.dependency "RadarSDK", "~> 3.19.2-beta.1"
 end

--- a/react-native-radar.podspec.template
+++ b/react-native-radar.podspec.template
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.summary = package[:description]
   s.source = { git: package[:repository][:url] }
   s.source_files = "ios/*.{h,m}"
-  s.platform = :ios, "10.0"
+  s.platform = :ios, "12.0"
 
   s.dependency "React"
   s.dependency "RadarSDK", "~> {{ version }}"

--- a/src/@types/RadarNativeInterface.ts
+++ b/src/@types/RadarNativeInterface.ts
@@ -60,6 +60,8 @@ export interface RadarNativeInterface {
   ) => Promise<RadarTrackCallback>;
   trackVerified: (options?: RadarTrackVerifiedOptions) => Promise<RadarTrackVerifiedCallback>;
   getVerifiedLocationToken: () => Promise<RadarTrackVerifiedCallback>;
+  startVerifyServer: () => void;
+  stopVerifyServer: () => void;
   startTrackingEfficient: () => void;
   startTrackingResponsive: () => void;
   startTrackingContinuous: () => void;

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -118,6 +118,12 @@ const trackVerified = (
 const getVerifiedLocationToken = (): Promise<RadarTrackVerifiedCallback> =>
   NativeModules.RNRadar.getVerifiedLocationToken();
 
+const startVerifyServer = (): void =>
+  NativeModules.RNRadar.startVerifyServer();
+
+const stopVerifyServer = (): void =>
+  NativeModules.RNRadar.stopVerifyServer();
+
 const startTrackingEfficient = (): void =>
   NativeModules.RNRadar.startTrackingEfficient();
 
@@ -263,6 +269,8 @@ const Radar: RadarNativeInterface = {
   trackOnce,
   trackVerified,
   getVerifiedLocationToken,
+  startVerifyServer,
+  stopVerifyServer,
   startTrackingEfficient,
   startTrackingResponsive,
   startTrackingContinuous,

--- a/src/index.web.js
+++ b/src/index.web.js
@@ -123,6 +123,14 @@ const getVerifiedLocationToken = () => {
   return new Promise((resolve, reject) => { reject("getVerifiedLocationToken() is not implemented on web") });
 };
 
+const startVerifyServer = () => {  
+  if (throws) throw new Error("startVerifyServer() is not implemented on web");
+};
+
+const stopVerifyServer = () => {  
+  if (throws) throw new Error("stopVerifyServer() is not implemented on web");
+};
+
 const startTrackingEfficient = () => {  
   if (throws) throw new Error("startTrackingEfficient() is not implemented on web");
 };

--- a/src/index.web.js
+++ b/src/index.web.js
@@ -489,6 +489,8 @@ const Radar = {
   trackOnce,
   trackVerified,
   getVerifiedLocationToken,
+  startVerifyServer,
+  stopVerifyServer,
   startTrackingEfficient,
   startTrackingResponsive,
   startTrackingContinuous,


### PR DESCRIPTION
- expose `startVerifyServer()` and `stopVerifyServer()`, allowing customers to turn their Android app into a "companion app" (https://radar.com/documentation/fraud#web-and-desktop) for `trackVerified()` and `startTrackingVerified()` on mobile
- see also https://github.com/radarlabs/radar-sdk-android/pull/417 and https://github.com/radarlabs/radar-sdk-ios/pull/417
- adds `addRadarSDKVerify` plugin option to add `NanoHTTPD` dependency and `Telegraph` sub-dependencies (`CocoaAsyncSocket` and `HTTPParserC` with `:modular_headers => true`)