### PR TITLE
[WIP] Spike on e2e testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ To run example app with local `react-native-radar` dependency:
 - build native app using expo pre-build and `react-native-plugin` with `npm run install-radar-rebuild`. 
 - run iOS and android example app with `npx expo run:ios` or `npx expo run:android`.
 
+### Example app tests
+
+If needed, install `maestro` with 
+```
+    brew tap mobile-dev-inc/tap
+    brew install maestro
+```
+
+Then, run tests with `maestro test example_tests.yaml`. from `/example/maestro` dir.
+
+
+
 
 ## Support
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { StyleSheet, Text, View, ScrollView, Platform } from "react-native";
+import { StyleSheet, Text, View, ScrollView, Platform, TextInput } from "react-native";
 import Radar, { Map, Autocomplete, RadarClientLocationUpdate, RadarLocationUpdate, RadarEventUpdate } from "react-native-radar";
 import MapLibreGL from "@maplibre/maplibre-react-native";
 import ExampleButton from "./components/exampleButton";
@@ -32,11 +32,12 @@ Radar.on("log", (result: string) => {
 export default function App() {
   // add in your test code here!
   const [displayText, setDisplayText] = useState("");
+  const [publishableKey, setPublishableKey] = useState("");
 
   const handlePopulateText = (displayText: string) => {
     setDisplayText(displayText);
   };
-  Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
+  //Radar.initialize("prj_test_pk_0000000000000000000000000000000000000000", true);
 
   useEffect(() => {
     Radar.setLogLevel("debug");
@@ -77,6 +78,32 @@ export default function App() {
           <Text style={styles.displayText}>{displayText}</Text>
         </ScrollView>
         <ScrollView style={{ height: "75%" }}>
+          <TextInput
+          id="publishableKeyInput"
+          value={publishableKey}
+          onChangeText={(text) => setPublishableKey(text)}
+          placeholder="Enter publishable key"
+          style={{ height: 40, borderColor: 'gray', borderWidth: 1, margin: 10, padding: 5 }}
+          />
+          <ExampleButton
+            title="initialize"
+            onPress={() => {
+              Radar.initialize(publishableKey, true);
+                
+            }}
+          />
+          <ExampleButton
+            title="trackOnce"
+            onPress={() => {
+              Radar.trackOnce()
+                .then((result) => {
+                  handlePopulateText("trackOnce:" + stringify(result));
+                })
+                .catch((err) => {
+                  handlePopulateText("trackOnce:" + err);
+                });
+            }}
+          />
           <ExampleButton
             title="getUser"
             onPress={() => {

--- a/example/app.json
+++ b/example/app.json
@@ -16,14 +16,14 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.radar.example",
+      "bundleIdentifier": "com.radar.rnexample"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.radar.example"
+      "package": "com.radar.rnexample"
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -55,6 +55,12 @@
           }
         }
       ]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "caf6acc9-b3c5-4d95-af29-fd017a05abb8"
+      }
+    },
+    "owner": "radarlabs"
   }
 }

--- a/example/eas.json
+++ b/example/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 14.0.2",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/example/maestro/example_tests.yaml
+++ b/example/maestro/example_tests.yaml
@@ -1,0 +1,19 @@
+appId: com.radar.rnexample
+---
+- launchApp
+- assertVisible: 'getUser'
+- tapOn: "Enter publishable key"
+- inputText:
+    text: '${MAESTRO_RADAR_PUBLISHABLE_KEY}'
+- hideKeyboard
+- tapOn:
+    text: 'Initialize'
+- setLocation:
+    latitude: 52.3599976
+    longitude: 4.8830301
+- tapOn:
+    text: 'trackOnce'
+- extendedWaitUntil:
+    visible: '.*SUCCESS.*'
+    timeout: 10000      # Timeout in milliseconds
+


### PR DESCRIPTION
This PR attempts to do the following
- make example app more usable by e2e tester
    - have user inputed publishable key
- implement maestro flow to perform e2e
- configure building example app and running the e2e on EAS (not working yet)

Intention: We should be able to deduct that an app can build/run with react native radar and is able to call some important Radar calls, returning valid responses.