### PR TITLE
feat: add MapLibreGL loading events to Radar Map component

### DIFF
--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -143,7 +143,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
     override fun initialize(publishableKey: String, fraud: Boolean): Unit {
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "3.23.2")
+        editor.putString("x_platform_sdk_version", "3.23.3")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -102,7 +102,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.23.2");
+        editor.putString("x_platform_sdk_version", "3.23.3");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 

--- a/copyAssets.sh
+++ b/copyAssets.sh
@@ -3,7 +3,16 @@
 source_dir="./src/ui"  
 target_dir="./dist/ui"
 
+# Copy PNG files
 for file in "$source_dir"/*.png
 do
   cp "$file" "$target_dir"
+done
+
+# Copy JSX files (JavaScript implementations)
+for file in "$source_dir"/*.jsx
+do
+  if [ -f "$file" ]; then
+    cp "$file" "$target_dir"
+  fi
 done

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -31,7 +31,7 @@ if (host) {
 }
 
 
-Radar.initialize("prj_test_pk_e3bd55ab250955926cdd76c2baeb2ed559434925", true);
+Radar.initialize("prj_test_pk_", true);
 const stringify = (obj: any) => JSON.stringify(obj, null, 2);
 declare global {
   var __turboModuleProxy: any;

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -9,6 +9,7 @@ import {
   Settings
 } from "react-native";
 import Radar, { Map, Autocomplete } from "react-native-radar";
+import type { RadarMapOptions } from "react-native-radar";
 import React, { useEffect, useState } from "react";
 import ExampleButton from "./components/exampleButton";
 import MapLibreGL from "@maplibre/maplibre-react-native";
@@ -30,7 +31,7 @@ if (host) {
 }
 
 
-Radar.initialize("prj_test_pk_", true);
+Radar.initialize("prj_test_pk_e3bd55ab250955926cdd76c2baeb2ed559434925", true);
 const stringify = (obj: any) => JSON.stringify(obj, null, 2);
 declare global {
   var __turboModuleProxy: any;
@@ -806,6 +807,26 @@ export default function App() {
       });
   }, []);
 
+  const mapOptions: RadarMapOptions = {
+    mapStyle: 'radar-default-v1',
+    onDidFinishLoadingMap: () => {
+      console.log('Map finished loading');
+      populateText('Map finished loading');
+    },
+    onWillStartLoadingMap: () => {
+      console.log('Map will start loading');
+      populateText('Map will start loading');
+    },
+    onDidFailLoadingMap: () => {
+      console.log('Map failed to load');
+      populateText('Map failed to load');
+    },
+    onRegionDidChange: (feature) => {
+      console.log('Map region changed:', feature);
+      populateText('Map region changed: ' + JSON.stringify(feature));
+    }
+  };
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
@@ -820,7 +841,7 @@ export default function App() {
         {Platform.OS !== "web" && (
           <>
             <View style={{ width: "100%", height: "25%" }}>
-              <Map />
+              <Map mapOptions={mapOptions} />
             </View>
             <View style={{ width: "100%", height: "10%" }}>
               <Autocomplete

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "..": {
-      "version": "3.23.1",
+      "version": "3.23.3",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "..": {
-      "version": "3.23.0-beta.2",
+      "version": "3.23.1",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -46,6 +46,7 @@
         "@react-native/eslint-config": "^0.78.0",
         "@release-it/conventional-changelog": "^9.0.2",
         "@types/jest": "^29.5.5",
+        "@types/node": "^24.3.0",
         "@types/react": "^19.0.0",
         "commitlint": "^19.6.1",
         "del-cli": "^5.1.0",
@@ -3739,6 +3740,7 @@
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-7.1.12.tgz",
       "integrity": "sha512-fkCRkOgzfdD0sr8JTasDgm716l8bJPkCNjXIyllG8K+UyixVa68lroQmgW9pewE5G5p43I9MWPtGZR/kVowBzg==",
+      "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.59"
       }
@@ -8725,7 +8727,8 @@
     "node_modules/radar-sdk-js": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg=="
+      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
+      "license": "Apache-2.0"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8869,7 +8869,7 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.23.2",
+      "version": "3.23.3",
       "resolved": "file:..",
       "license": "Apache-2.0",
       "dependencies": {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.2" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.3" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.23.2",
+      "version": "3.23.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -846,3 +846,11 @@ export type RadarTripStatus =
   | "expired"
   | "completed"
   | "canceled";
+
+export interface RadarMapOptions {
+  mapStyle?: string;
+  onRegionDidChange?: (feature: any) => void;
+  onDidFinishLoadingMap?: () => void;
+  onWillStartLoadingMap?: () => void;
+  onDidFailLoadingMap?: () => void;
+}

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -849,8 +849,16 @@ export type RadarTripStatus =
 
 export interface RadarMapOptions {
   mapStyle?: string;
-  onRegionDidChange?: (feature: any) => void;
+  onRegionDidChange?: (feature: RadarMapRegionChangeEvent) => void;
   onDidFinishLoadingMap?: () => void;
   onWillStartLoadingMap?: () => void;
   onDidFailLoadingMap?: () => void;
+}
+
+export interface RadarMapRegionChangeEvent {
+  center: [number, number];
+  zoom: number;
+  bounds?: [number, number, number, number];
+  bearing?: number;
+  pitch?: number;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,5 +21,7 @@ export { Autocomplete };
 let Map = Platform.OS !== "web" ? require("./ui/map").default : {};
 export { Map };
 
+export type { RadarMapProps } from "./ui/map";
+
 export * from "./@types/types";
 export * from "./@types/RadarNativeInterface";

--- a/src/ui/map.jsx
+++ b/src/ui/map.jsx
@@ -19,6 +19,20 @@ const createStyleURL = async (style = DEFAULT_STYLE) => {
   return `${host}/maps/styles/${style}?publishableKey=${publishableKey}`;
 };
 
+/**
+ * RadarMap component for displaying maps with Radar integration
+ * @param {Object} props - Component props
+ * @param {Object} [props.mapOptions] - Map configuration options
+ * @param {string} [props.mapOptions.mapStyle] - Map style identifier (defaults to 'radar-default-v1')
+ * @param {function} [props.mapOptions.onRegionDidChange] - Callback fired when the map region changes
+ * @param {Object} props.mapOptions.onRegionDidChange.feature - The region feature data
+ * @param {function} [props.mapOptions.onDidFinishLoadingMap] - Callback fired when the map finishes loading
+ * @param {function} [props.mapOptions.onWillStartLoadingMap] - Callback fired when the map starts loading
+ * @param {function} [props.mapOptions.onDidFailLoadingMap] - Callback fired when the map fails to load
+ * @param {React.ReactNode} [props.children] - Child components to render within the map
+ * @returns {React.Component|null} The RadarMap component or null if dependencies are missing
+ */
+
 const RadarMap = ({ mapOptions, children }) => {
   const [styleURL, setStyleURL] = useState(null);
   const [userLocation, setUserLocation] = useState(null);

--- a/src/ui/map.jsx
+++ b/src/ui/map.jsx
@@ -106,6 +106,9 @@ const RadarMap = ({ mapOptions, children }) => {
         logoEnabled={false}
         attributionEnabled
         onRegionDidChange={mapOptions?.onRegionDidChange ? mapOptions.onRegionDidChange : null}
+        onDidFinishLoadingMap={mapOptions?.onDidFinishLoadingMap ? mapOptions.onDidFinishLoadingMap : null}
+        onWillStartLoadingMap={mapOptions?.onWillStartLoadingMap ? mapOptions.onWillStartLoadingMap : null}
+        onDidFailLoadingMap={mapOptions?.onDidFailLoadingMap ? mapOptions.onDidFailLoadingMap : null}
         mapStyle={styleURL}>
         {userLocationMapIndicator}
         {children}

--- a/src/ui/map.tsx
+++ b/src/ui/map.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { RadarMapOptions } from '../@types/types';
+
+const RadarMapJS = require('./map.jsx').default;
+
+export interface RadarMapProps {
+  /**
+   * Configuration options for the RadarMap component
+   */
+  mapOptions?: RadarMapOptions;
+  /**
+   * Child components to render within the map
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * TypeScript wrapper for the RadarMap component that provides type safety
+ * while delegating the implementation to the JavaScript version.
+ * 
+ * @param props - The props for the RadarMap component
+ * @returns The RadarMap component with proper TypeScript typing
+ */
+const RadarMap: React.FC<RadarMapProps> = (props) => {
+  return React.createElement(RadarMapJS, props);
+};
+
+export default RadarMap;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '3.23.2';
+export const VERSION = '3.23.3';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "src/index.tsx",
     "src/index.web.js",
     "src/ui/**/*",
-    "src/NativeRadar.ts"
+    "src/NativeRadar.ts",
+    "src/helpers.js"
   ],
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
   "include": [
     "src/index.tsx",
     "src/index.web.js",
-    "src/ui",
+    "src/ui/**/*",
     "src/NativeRadar.ts"
   ],
   "exclude": [


### PR DESCRIPTION
- Add onDidFinishLoadingMap event forwarding
- Add onWillStartLoadingMap event forwarding
- Add onDidFailLoadingMap event forwarding
- Update TypeScript definitions for new events
- Maintains existing mapOptions API pattern
- Fixes issue where loading events were ignored

Resolves customer request for onDidFinishLoadingMap support

**New Architecture**
<img width="1080" height="2400" alt="new-arch-android" src="https://github.com/user-attachments/assets/c6830218-8ab0-4d46-b628-0ef75fc5d0a4" />

<img width="1290" height="2796" alt="new-arch-ios" src="https://github.com/user-attachments/assets/a56bcaf5-7a8d-4404-bf62-e96af7c9a8b7" />


**Old Architecture**
<img width="1290" height="2796" alt="old-arch-ios" src="https://github.com/user-attachments/assets/0f26cd7a-43a7-488a-b1d7-dc49ef3ac78f" />

<img width="1080" height="2400" alt="old-arch-android" src="https://github.com/user-attachments/assets/e90954ea-bd52-47d1-8d1b-a0ad0f27a431" />



