### PR TITLE
FENCE-2455 Add proguard rules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,7 @@ android {
   buildTypes {
     release {
       minifyEnabled false
+      consumerProguardFiles "proguard-rules.pro"
     }
   }
 

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,4 @@
+-dontwarn com.huawei.**
+
+-dontwarn com.google.android.play.integrity.**
+-dontwarn com.google.android.play.core.integrity.**

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -143,7 +143,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
     override fun initialize(publishableKey: String, fraud: Boolean): Unit {
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "3.23.3")
+        editor.putString("x_platform_sdk_version", "3.23.4")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -102,7 +102,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.23.3");
+        editor.putString("x_platform_sdk_version", "3.23.4");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 

--- a/example/app.json
+++ b/example/app.json
@@ -69,7 +69,7 @@
           "android": {
             "enableProguardInReleaseBuilds": true,
             "enableShrinkResourcesInReleaseBuilds": true,
-            "newArchEnabled": false
+            "newArchEnabled": true
           }
         }
       ]

--- a/example/app.json
+++ b/example/app.json
@@ -69,7 +69,7 @@
           "android": {
             "enableProguardInReleaseBuilds": true,
             "enableShrinkResourcesInReleaseBuilds": true,
-            "newArchEnabled": true
+            "newArchEnabled": false
           }
         }
       ]

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8869,7 +8869,7 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.23.3",
+      "version": "3.23.4",
       "resolved": "file:..",
       "license": "Apache-2.0",
       "dependencies": {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.3" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.4" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.23.3",
+      "version": "3.23.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '3.23.3';
+export const VERSION = '3.23.4';


### PR DESCRIPTION
- Adds `proguard-rules.pro` to Android 
- Resolves build error when building Android apps with R8 
- Bumps version to  `3.23.4`


**Testing**
- Build example app with `npx expo run:android --variant release`
- Verify R8 compile error 
- Add proguard rules
- Run release build again 


**Android Screenshots**


<img width="1080" height="2400" alt="Screenshot_1758294791" src="https://github.com/user-attachments/assets/af92c68c-2ddd-4be9-adcf-e8cc92a2fc3b" />

<img width="1080" height="2400" alt="Screenshot_1758295177" src="https://github.com/user-attachments/assets/b47dff0b-1c19-4c65-92a8-e400b85c1286" />

