### PR TITLE
FENCE-2457 Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,18 +56,24 @@ jobs:
       - run:
           name: Configure Gradle
           command: |
+            echo "Creating .gradle directory..."
             mkdir -p ~/.gradle
+            echo "Writing gradle.properties..."
             echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+UseG1GC" >> ~/.gradle/gradle.properties
             echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
             echo "org.gradle.parallel=false" >> ~/.gradle/gradle.properties
             echo "org.gradle.configureondemand=false" >> ~/.gradle/gradle.properties
+            echo "Gradle properties configured:"
+            cat ~/.gradle/gradle.properties
+            echo "Directory permissions:"
+            ls -la ~/.gradle/
       - run: chown -R $USER:$USER android
       - run: 
           name: Build Android Debug
           command: | 
             cd android 
             ./gradlew clean --no-daemon
-            ./gradlew assembleDebug --no-daemon --info --stacktrace
+            ./gradlew assembleDebug --no-daemon --info
   ios:
     macos:
       xcode: "15.3.0"


### PR DESCRIPTION
- Update build step in Android job to include `assembleDebug --no-daemon --info`
- Add `environment` variables to Android job to manage memory usage
- Add `Configure Gradle` step to Android job to prevent timeout in build step


**Testing**

Previous CI result
<img width="1065" height="578" alt="image" src="https://github.com/user-attachments/assets/b968d6d2-2629-41a4-ab3a-c97d4d8b4c94" />

Current CI result
<img width="943" height="630" alt="image" src="https://github.com/user-attachments/assets/3d10a1a7-361e-46ff-bcfe-96057aad80d6" />
