### PR TITLE
FENCE-2485 Fix Android CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,11 @@ jobs:
     working_directory: ~/react-native-radar/example
     docker:
       - image: cimg/android:2024.01.1-browsers
-    resource_class: large
+    resource_class: xlarge
     environment:
       JAVA_OPTS: "-Xmx2g -XX:+UseG1GC"
-      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
+      ANDROID_NDK_MAX_PARALLEL_JOBS: "2"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.workers.max=2"
       NODE_OPTIONS: "--max-old-space-size=2048"
     steps:
       - attach_workspace:

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "..": {
-      "version": "3.23.3",
+      "version": "3.23.4",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
- Updates `resource_class` to `xlarge`
- Removes memory limits from `GRADLE_OPTS` 
- Sets `ANDROID_NDX_MAX_PARALLEL_JOBS` to 2 

Failing CI 
<img width="1665" height="685" alt="image" src="https://github.com/user-attachments/assets/adaeb84a-8d36-412d-80c1-55915cdaad48" />

Fixed CI
<img width="1130" height="623" alt="image" src="https://github.com/user-attachments/assets/85e38746-cc3e-4a9d-987a-140cb7e10414" />
