### PR TITLE
FENCE-2502: Add optional showUserLocation param to mapOptions

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -829,6 +829,7 @@ export default function App() {
 
   const mapOptions: RadarMapOptions = {
     mapStyle: 'radar-default-v1',
+    showUserLocation: true,
     onDidFinishLoadingMap: () => {
       console.log('Map finished loading');
       populateText('Map finished loading');

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -28,6 +28,7 @@
     },
     "..": {
       "version": "3.23.5",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -64,7 +65,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@maplibre/maplibre-react-native": ">=10.0.1",
+        "@maplibre/maplibre-react-native": ">=10.2.1",
         "expo": ">=43.0.5",
         "react": ">= 16.8.6",
         "react-native": ">= 0.60.0"
@@ -6697,6 +6698,12 @@
         "inherits": "~2.0.3"
       }
     },
+    "node_modules/radar-sdk-js": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
+      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6817,8 +6824,27 @@
       }
     },
     "node_modules/react-native-radar": {
-      "resolved": "..",
-      "link": true
+      "version": "3.23.5",
+      "resolved": "file:..",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "radar-sdk-js": "^3.7.1"
+      },
+      "peerDependencies": {
+        "@maplibre/maplibre-react-native": ">=10.2.1",
+        "expo": ">=43.0.5",
+        "react": ">= 16.8.6",
+        "react-native": ">= 0.60.0"
+      },
+      "peerDependenciesMeta": {
+        "@maplibre/maplibre-react-native": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-native-web": {
       "version": "0.21.1",

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "strict": true
   }
 }

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -849,6 +849,7 @@ export type RadarTripStatus =
 
 export interface RadarMapOptions {
   mapStyle?: string;
+  showUserLocation?: boolean;
   onRegionDidChange?: (feature: RadarMapRegionChangeEvent) => void;
   onDidFinishLoadingMap?: () => void;
   onWillStartLoadingMap?: () => void;

--- a/src/ui/map.jsx
+++ b/src/ui/map.jsx
@@ -24,6 +24,7 @@ const createStyleURL = async (style = DEFAULT_STYLE) => {
  * @param {Object} props - Component props
  * @param {Object} [props.mapOptions] - Map configuration options
  * @param {string} [props.mapOptions.mapStyle] - Map style identifier (defaults to 'radar-default-v1')
+ * @param {boolean} [props.mapOptions.showUserLocation] - Whether to show the user's location on the map (default: true)
  * @param {function} [props.mapOptions.onRegionDidChange] - Callback fired when the map region changes
  * @param {Object} props.mapOptions.onRegionDidChange.feature - The region feature data
  * @param {function} [props.mapOptions.onDidFinishLoadingMap] - Callback fired when the map finishes loading
@@ -124,7 +125,7 @@ const RadarMap = ({ mapOptions, children }) => {
         onWillStartLoadingMap={mapOptions?.onWillStartLoadingMap ? mapOptions.onWillStartLoadingMap : null}
         onDidFailLoadingMap={mapOptions?.onDidFailLoadingMap ? mapOptions.onDidFailLoadingMap : null}
         mapStyle={styleURL}>
-        {userLocationMapIndicator}
+        {mapOptions?.showUserLocation !== false && userLocationMapIndicator}
         {children}
       </MapLibreGL.MapView>
       <Image


### PR DESCRIPTION
- Adds `showUserLocation` parameter to `mapOptions`: defaults to true 
- Adds `jsx` flag to example `tsconfig` 


**Testing**

iOS old architecture `showUserLocation: true`
<img width="603" height="1311" alt="IMG_0066" src="https://github.com/user-attachments/assets/b63f4b0b-9ad2-4da2-abde-0c21d467d83f" />


iOS new architecture `showUserLocation: false`
<img width="603" height="1311" alt="IMG_0064" src="https://github.com/user-attachments/assets/4e696774-6a45-42de-a147-eef3e629b6e0" />

Android old architecture `showUserLocation: true`
![4185708107529016414](https://github.com/user-attachments/assets/b2242423-4486-48e0-9fd7-df01cae49d86)


Android new architecture `showUserLocation: false`
![9042267710003794759](https://github.com/user-attachments/assets/db05d80e-f2a9-4325-812f-316792df63b0)
