### PR TITLE
Feat: expose silent push methods

### DIFF
--- a/android/src/main/java/com/radar/RadarModuleImpl.java
+++ b/android/src/main/java/com/radar/RadarModuleImpl.java
@@ -1298,4 +1298,15 @@ public class RadarModuleImpl {
         }
         Radar.showInAppMessage(inAppMessage);
     }
+
+    public void setPushNotificationToken(String token) {
+        Radar.setPushNotificationToken(token);  
+    }
+
+    public void isInitialized(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+        promise.resolve(Radar.isInitialized());
+    }
 }

--- a/android/src/main/java/com/radar/RadarModuleImpl.java
+++ b/android/src/main/java/com/radar/RadarModuleImpl.java
@@ -1309,4 +1309,12 @@ public class RadarModuleImpl {
         }
         promise.resolve(Radar.isInitialized());
     }
+
+    public void setAppGroup(String groupId) {
+        // No-op on Android - app groups are iOS-specific
+    }
+
+    public void setLocationExtensionToken(String token) {
+        // No-op on Android - location extensions are iOS-specific
+    }
 }

--- a/android/src/main/java/com/radar/RadarModuleImpl.java
+++ b/android/src/main/java/com/radar/RadarModuleImpl.java
@@ -1300,7 +1300,7 @@ public class RadarModuleImpl {
     }
 
     public void setPushNotificationToken(String token) {
-        Radar.setPushNotificationToken(token);  
+        Radar.setPushNotificationToken(token);
     }
 
     public void isInitialized(final Promise promise) {

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -441,6 +441,14 @@ class RadarModule(reactContext: ReactApplicationContext) :
         radarModuleImpl.isInitialized(promise)
     }
 
+    override fun setAppGroup(groupId: String): Unit {
+        radarModuleImpl.setAppGroup(groupId)
+    }
+
+    override fun setLocationExtensionToken(token: String): Unit {
+        radarModuleImpl.setLocationExtensionToken(token)
+    }
+
 
     companion object {
         const val NAME = "RNRadar"

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -144,7 +144,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         // options parameter is no-op on Android for now
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "3.23.7-beta.1")
+        editor.putString("x_platform_sdk_version", "3.23.7-beta.2")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -140,7 +140,8 @@ class RadarModule(reactContext: ReactApplicationContext) :
         return NAME
     }
 
-    override fun initialize(publishableKey: String, fraud: Boolean): Unit {
+    override fun initialize(publishableKey: String, fraud: Boolean, options: ReadableMap?): Unit {
+        // options parameter is no-op on Android for now
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
         editor.putString("x_platform_sdk_version", "3.23.6")
@@ -430,6 +431,14 @@ class RadarModule(reactContext: ReactApplicationContext) :
 
     override fun showInAppMessage(inAppMessage: ReadableMap): Unit {
         radarModuleImpl.showInAppMessage(inAppMessage)
+    }
+
+    override fun setPushNotificationToken(token: String): Unit {
+        radarModuleImpl.setPushNotificationToken(token)
+    }
+
+    override fun isInitialized(promise: Promise): Unit {
+        radarModuleImpl.isInitialized(promise)
     }
 
 

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -144,7 +144,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         // options parameter is no-op on Android for now
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "3.23.6")
+        editor.putString("x_platform_sdk_version", "3.23.6-beta.1")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -144,7 +144,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         // options parameter is no-op on Android for now
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "3.23.6-beta.1")
+        editor.putString("x_platform_sdk_version", "3.23.7-beta.1")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -144,7 +144,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         // options parameter is no-op on Android for now
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "3.23.7-beta.2")
+        editor.putString("x_platform_sdk_version", "3.23.7-beta.3")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -103,7 +103,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.23.7-beta.1");
+        editor.putString("x_platform_sdk_version", "3.23.7-beta.2");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -103,7 +103,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.23.7-beta.2");
+        editor.putString("x_platform_sdk_version", "3.23.7-beta.3");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -103,7 +103,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.23.6-beta.1");
+        editor.putString("x_platform_sdk_version", "3.23.7-beta.1");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -455,4 +455,14 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         radarModuleImpl.isInitialized(promise);
     }
 
+    @ReactMethod
+    public void setAppGroup(String groupId) {
+        radarModuleImpl.setAppGroup(groupId);
+    }
+
+    @ReactMethod
+    public void setLocationExtensionToken(String token) {
+        radarModuleImpl.setLocationExtensionToken(token);
+    }
+
 }

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -103,7 +103,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "3.23.6");
+        editor.putString("x_platform_sdk_version", "3.23.6-beta.1");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -98,7 +98,8 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
     }
 
     @ReactMethod
-    public void initialize(String publishableKey, boolean fraud) {
+    public void initialize(String publishableKey, boolean fraud, ReadableMap options) {
+        // options parameter is no-op on Android for now
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
@@ -442,6 +443,16 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
     @ReactMethod
     public void showInAppMessage(ReadableMap inAppMessageMap) {
         radarModuleImpl.showInAppMessage(inAppMessageMap);
+    }
+
+    @ReactMethod
+    public void setPushNotificationToken(String token) {
+        radarModuleImpl.setPushNotificationToken(token);
+    }
+
+    @ReactMethod
+    public void isInitialized(final Promise promise) {
+        radarModuleImpl.isInitialized(promise);
     }
 
 }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6824,7 +6824,7 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.23.7-beta.1",
+      "version": "3.23.7-beta.2",
       "resolved": "file:..",
       "license": "Apache-2.0",
       "dependencies": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -28,7 +28,6 @@
     },
     "..": {
       "version": "3.23.5",
-      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -6698,12 +6697,6 @@
         "inherits": "~2.0.3"
       }
     },
-    "node_modules/radar-sdk-js": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6824,27 +6817,8 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.23.6",
-      "resolved": "file:..",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "radar-sdk-js": "^3.7.1"
-      },
-      "peerDependencies": {
-        "@maplibre/maplibre-react-native": ">=10.2.1",
-        "expo": ">=43.0.5",
-        "react": ">= 16.8.6",
-        "react-native": ">= 0.60.0"
-      },
-      "peerDependenciesMeta": {
-        "@maplibre/maplibre-react-native": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        }
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/react-native-web": {
       "version": "0.21.1",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,8 @@
       }
     },
     "..": {
-      "version": "3.23.5",
+      "version": "3.23.7-beta.1",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -6697,6 +6698,12 @@
         "inherits": "~2.0.3"
       }
     },
+    "node_modules/radar-sdk-js": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
+      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6817,8 +6824,27 @@
       }
     },
     "node_modules/react-native-radar": {
-      "resolved": "..",
-      "link": true
+      "version": "3.23.7-beta.1",
+      "resolved": "file:..",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "radar-sdk-js": "^3.7.1"
+      },
+      "peerDependencies": {
+        "@maplibre/maplibre-react-native": ">=10.2.1",
+        "expo": ">=43.0.5",
+        "react": ">= 16.8.6",
+        "react-native": ">= 0.60.0"
+      },
+      "peerDependenciesMeta": {
+        "@maplibre/maplibre-react-native": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-native-web": {
       "version": "0.21.1",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6824,7 +6824,7 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "3.23.7-beta.2",
+      "version": "3.23.7-beta.3",
       "resolved": "file:..",
       "license": "Apache-2.0",
       "dependencies": {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -184,10 +184,15 @@ RCT_EXPORT_MODULE()
     #endif
 }
 
-RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
+RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
     [[NSUserDefaults standardUserDefaults] setObject:@"3.23.6" forKey:@"radar-xPlatformSDKVersion"];
-    [Radar initializeWithPublishableKey:publishableKey];
+    
+    RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
+    if (options[@"silentPush"]) {
+        radarOptions.silentPush = [options[@"silentPush"] boolValue];
+    }
+    [Radar initializeWithPublishableKey:publishableKey options:radarOptions];
 }
 
 RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {
@@ -1292,6 +1297,15 @@ RCT_EXPORT_METHOD(showInAppMessage:(NSDictionary *)inAppMessageDict) {
     if (inAppMessage != nil) {
         [Radar showInAppMessage:inAppMessage];
     }
+}
+
+RCT_EXPORT_METHOD(setPushNotificationToken:(NSString *)token) {
+    // No-op on iOS - push notifications are configured differently
+    // iOS uses didRegisterForRemoteNotificationsWithDeviceToken in AppDelegate
+}
+
+RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    resolve(@(Radar.isInitialized));
 }
 
 RCT_EXPORT_METHOD(logConversion:(NSDictionary *)optionsDict resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.6-beta.1" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.7-beta.1" forKey:@"radar-xPlatformSDKVersion"];
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil && options[@"silentPush"]) {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -1304,6 +1304,14 @@ RCT_EXPORT_METHOD(setPushNotificationToken:(NSString *)token) {
     // iOS uses didRegisterForRemoteNotificationsWithDeviceToken in AppDelegate
 }
 
+RCT_EXPORT_METHOD(setAppGroup:(NSString *)groupId) {
+    [Radar setAppGroup:groupId];
+}
+
+RCT_EXPORT_METHOD(setLocationExtensionToken:(NSString *)token) {
+    [Radar setLocationExtensionToken:token];
+}
+
 RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     resolve(@(Radar.isInitialized));
 }

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -189,7 +189,7 @@ RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud option
     [[NSUserDefaults standardUserDefaults] setObject:@"3.23.6" forKey:@"radar-xPlatformSDKVersion"];
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
-    if (options[@"silentPush"]) {
+    if (options != nil && options[@"silentPush"]) {
         radarOptions.silentPush = [options[@"silentPush"] boolValue];
     }
     [Radar initializeWithPublishableKey:publishableKey options:radarOptions];

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.7-beta.2" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.7-beta.3" forKey:@"radar-xPlatformSDKVersion"];
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil && options[@"silentPush"]) {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.6" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.6-beta.1" forKey:@"radar-xPlatformSDKVersion"];
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil && options[@"silentPush"]) {

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.7-beta.1" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.23.7-beta.2" forKey:@"radar-xPlatformSDKVersion"];
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil && options[@"silentPush"]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.23.7-beta.2",
+  "version": "3.23.7-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.23.7-beta.2",
+      "version": "3.23.7-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.23.7-beta.1",
+  "version": "3.23.7-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.23.7-beta.1",
+      "version": "3.23.7-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.23.6-beta.1",
+  "version": "3.23.7-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.23.6-beta.1",
+      "version": "3.23.7-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "3.23.6",
+  "version": "3.23.6-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "3.23.6",
+      "version": "3.23.6-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.23.6-beta.1",
+  "version": "3.23.7-beta.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.23.6",
+  "version": "3.23.6-beta.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.23.7-beta.1",
+  "version": "3.23.7-beta.2",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.23.7-beta.2",
+  "version": "3.23.7-beta.3",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/@types/RadarNativeInterface.ts
+++ b/src/@types/RadarNativeInterface.ts
@@ -49,7 +49,7 @@ import type {
 } from "./types";
 
 export interface RadarNativeInterface {
-  initialize: (publishableKey: string, fraud?: boolean) => void;
+  initialize: (publishableKey: string, fraud?: boolean, options?: Object | null) => void;
   setLogLevel: (level: RadarLogLevel) => void;
   setUserId: (userId: string) => void;
   getUserId: () => Promise<string>;
@@ -124,6 +124,8 @@ export interface RadarNativeInterface {
   nativeSdkVersion: () => Promise<string>;
   rnSdkVersion: () => string;
   showInAppMessage: (inAppMessage: RadarInAppMessage) => void;
+  setPushNotificationToken: (token: string) => void;
+  isInitialized: () => Promise<boolean>;
 
   onLocationUpdated: (callback: RadarLocationUpdateCallback | null) => void;
   onClientLocationUpdated: (

--- a/src/@types/RadarNativeInterface.ts
+++ b/src/@types/RadarNativeInterface.ts
@@ -126,6 +126,8 @@ export interface RadarNativeInterface {
   showInAppMessage: (inAppMessage: RadarInAppMessage) => void;
   setPushNotificationToken: (token: string) => void;
   isInitialized: () => Promise<boolean>;
+  setAppGroup: (groupId: string) => void;
+  setLocationExtensionToken: (token: string) => void;
 
   onLocationUpdated: (callback: RadarLocationUpdateCallback | null) => void;
   onClientLocationUpdated: (

--- a/src/NativeRadar.ts
+++ b/src/NativeRadar.ts
@@ -43,7 +43,7 @@ export type InAppMessageClickedEmitter = {
 };
 
 export interface Spec extends TurboModule {
-  initialize(publishableKey: string, fraud: boolean): void;
+  initialize(publishableKey: string, fraud: boolean, options: Object | null): void;
   requestPermissions(background: boolean): Promise<string>;
   getPermissionsStatus(): Promise<string>;
   trackOnce(trackOnceOptions: Object | null): Promise<Object>;
@@ -101,6 +101,8 @@ export interface Spec extends TurboModule {
   getHost(): Promise<string>;
   getPublishableKey(): Promise<string>;
   showInAppMessage(inAppMessage: Object): void;
+  setPushNotificationToken(token: string): void;
+  isInitialized(): Promise<boolean>;
   readonly locationEmitter: EventEmitter<LocationEmitter>;
   readonly clientLocationEmitter: EventEmitter<ClientLocationEmitter>;
   readonly errorEmitter: EventEmitter<ErrorEmitter>;

--- a/src/NativeRadar.ts
+++ b/src/NativeRadar.ts
@@ -103,6 +103,8 @@ export interface Spec extends TurboModule {
   showInAppMessage(inAppMessage: Object): void;
   setPushNotificationToken(token: string): void;
   isInitialized(): Promise<boolean>;
+  setAppGroup(groupId: string): void;
+  setLocationExtensionToken(token: string): void;
   readonly locationEmitter: EventEmitter<LocationEmitter>;
   readonly clientLocationEmitter: EventEmitter<ClientLocationEmitter>;
   readonly errorEmitter: EventEmitter<ErrorEmitter>;

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -326,6 +326,20 @@ const Radar: RadarNativeInterface = {
     // See: https://docs.radar.com/sdk/silent-push#silent-push
   },
 
+  setAppGroup: (groupId: string) => {
+    if (Platform.OS === 'ios') {
+      return NativeRadar.setAppGroup(groupId);
+    }
+    // Android doesn't support app groups
+  },
+
+  setLocationExtensionToken: (token: string) => {
+    if (Platform.OS === 'ios') {
+      return NativeRadar.setLocationExtensionToken(token);
+    }
+    // Android doesn't support location extensions
+  },
+
   requestPermissions: (background: boolean) => {
     return NativeRadar.requestPermissions(
       background

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -1,4 +1,5 @@
 import type { EventSubscription } from "react-native";
+import { Platform } from "react-native";
 import type { RadarNativeInterface } from "./@types/RadarNativeInterface";
 import type {
   RadarTrackCallback,
@@ -118,8 +119,8 @@ let inAppMessageDismissedUpdateSubscription: EventSubscription | null = null;
 let inAppMessageClickedUpdateSubscription: EventSubscription | null = null;
 
 const Radar: RadarNativeInterface = {
-  initialize: (publishableKey: string, fraud?: boolean) => {
-    NativeRadar.initialize(publishableKey, !!fraud);
+  initialize: (publishableKey: string, fraud?: boolean, options?: Object | null) => {
+    NativeRadar.initialize(publishableKey, !!fraud, options || null);
     Radar.onNewInAppMessage((inAppMessage) => {
       Radar.showInAppMessage(inAppMessage);
     });
@@ -315,6 +316,14 @@ const Radar: RadarNativeInterface = {
 
   showInAppMessage: (inAppMessage: RadarInAppMessage) => {
     return NativeRadar.showInAppMessage(inAppMessage);
+  },
+
+  setPushNotificationToken: (token: string) => {
+    if (Platform.OS === 'android') {
+      return NativeRadar.setPushNotificationToken(token);
+    }
+    // iOS handles push notifications differently via AppDelegate
+    // See: https://docs.radar.com/sdk/silent-push#silent-push
   },
 
   requestPermissions: (background: boolean) => {
@@ -533,6 +542,9 @@ const Radar: RadarNativeInterface = {
   },
   getPublishableKey: function (): Promise<string> {
     return NativeRadar.getPublishableKey();
+  },
+  isInitialized: function (): Promise<boolean> {
+    return NativeRadar.isInitialized();
   },
 };
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '3.23.6-beta.1';
+export const VERSION = '3.23.7-beta.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '3.23.7-beta.2';
+export const VERSION = '3.23.7-beta.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '3.23.6';
+export const VERSION = '3.23.6-beta.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '3.23.7-beta.1';
+export const VERSION = '3.23.7-beta.2';


### PR DESCRIPTION
- Adds `Radar.isInitialized()` for android silent push re-initialization logic
- Adds `Radar.setPushNotificationToken()` for android silent push setup 
- Adds `initializeOptions` to `Radar.Initialize()` for iOS silent push 