### PR TITLE
FENCE-2730: Add Silent Push

### DIFF
--- a/android/src/main/java/com/radar/RadarModuleImpl.java
+++ b/android/src/main/java/com/radar/RadarModuleImpl.java
@@ -1298,4 +1298,23 @@ public class RadarModuleImpl {
         }
         Radar.showInAppMessage(inAppMessage);
     }
+
+    public void setPushNotificationToken(String token) {
+        Radar.setPushNotificationToken(token);
+    }
+
+    public void isInitialized(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+        promise.resolve(Radar.isInitialized());
+    }
+
+    public void setAppGroup(String groupId) {
+        // No-op on Android - app groups are iOS-specific
+    }
+    
+    public void setLocationExtensionToken(String token) {
+        // No-op on Android - location extensions are iOS-specific
+    }
 }

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -140,7 +140,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         return NAME
     }
 
-    override fun initialize(publishableKey: String, fraud: Boolean): Unit {
+    override fun initialize(publishableKey: String, fraud: Boolean, options: ReadableMap?): Unit {
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
         editor.putString("x_platform_sdk_version", "4.0.0")
@@ -432,6 +432,21 @@ class RadarModule(reactContext: ReactApplicationContext) :
         radarModuleImpl.showInAppMessage(inAppMessage)
     }
 
+    override fun setPushNotificationToken(token: String): Unit {
+        radarModuleImpl.setPushNotificationToken(token)
+    }
+
+    override fun isInitialized(promise: Promise): Unit {
+        radarModuleImpl.isInitialized(promise)
+    }
+
+    override fun setAppGroup(groupId: String): Unit {
+        radarModuleImpl.setAppGroup(groupId)
+    }
+    
+    override fun setLocationExtensionToken(token: String): Unit {
+        radarModuleImpl.setLocationExtensionToken(token)
+    }
 
     companion object {
         const val NAME = "RNRadar"

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -98,7 +98,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
     }
 
     @ReactMethod
-    public void initialize(String publishableKey, boolean fraud) {
+    public void initialize(String publishableKey, boolean fraud, ReadableMap options) {
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
@@ -444,4 +444,23 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         radarModuleImpl.showInAppMessage(inAppMessageMap);
     }
 
+    @ReactMethod
+    public void setPushNotificationToken(String token) {
+        radarModuleImpl.setPushNotificationToken(token);
+    }
+
+    @ReactMethod
+    public void isInitialized(final Promise promise) {
+        radarModuleImpl.isInitialized(promise);
+    }
+
+    @ReactMethod
+    public void setAppGroup(String groupId) {
+        radarModuleImpl.setAppGroup(groupId);
+    }
+
+    @ReactMethod
+    public void setLocationExtensionToken(String token) {
+        radarModuleImpl.setLocationExtensionToken(token);
+    }
 }

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -214,11 +214,24 @@ RCT_EXPORT_MODULE()
     #endif
 }
 
-RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud) {
+RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     _publishableKey = publishableKey; 
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
     [[NSUserDefaults standardUserDefaults] setObject:@"4.0.0" forKey:@"radar-xPlatformSDKVersion"];
-    [Radar initializeWithPublishableKey:publishableKey];
+    
+    RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
+    if (options != nil) {
+        if (options[@"silentPush"]) {
+            radarOptions.silentPush = [options[@"silentPush"] boolValue];
+        }
+        if (options[@"autoLogNotificationConversions"]) {
+            radarOptions.autoLogNotificationConversions = [options[@"autoLogNotificationConversions"] boolValue];
+        }
+        if (options[@"autoHandleNotificationDeepLinks"]) {
+            radarOptions.autoHandleNotificationDeepLinks = [options[@"autoHandleNotificationDeepLinks"] boolValue];
+        }
+    }
+    [Radar initializeWithPublishableKey:publishableKey options:radarOptions];
 }
 
 RCT_EXPORT_METHOD(setLogLevel:(NSString *)level) {
@@ -1374,6 +1387,21 @@ RCT_EXPORT_METHOD(nativeSdkVersion:(RCTPromiseResolveBlock)resolve reject:(RCTPr
     resolve([Radar sdkVersion]);
 }
 
+RCT_EXPORT_METHOD(setPushNotificationToken:(NSString *)token) {
+    // No-op on iOS - push notifications are configured via AppDelegate
+}
+
+RCT_EXPORT_METHOD(setAppGroup:(NSString *)groupId) {
+    [Radar setAppGroup:groupId];
+}
+
+RCT_EXPORT_METHOD(setLocationExtensionToken:(NSString *)token) {
+    [Radar setLocationExtensionToken:token];
+}
+
+RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    resolve(@(Radar.isInitialized));
+}
 
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -221,14 +221,17 @@ RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud option
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil) {
-        if (options[@"silentPush"] != nil) {
-            radarOptions.silentPush = [options[@"silentPush"] boolValue];
+        id silentPushValue = options[@"silentPush"];
+        if (silentPushValue && silentPushValue != [NSNull null]) {
+            radarOptions.silentPush = [silentPushValue boolValue];
         }
-        if (options[@"autoLogNotificationConversions"] != nil) {
-            radarOptions.autoLogNotificationConversions = [options[@"autoLogNotificationConversions"] boolValue];
+        id autoLogValue = options[@"autoLogNotificationConversions"];
+        if (autoLogValue && autoLogValue != [NSNull null]) {
+            radarOptions.autoLogNotificationConversions = [autoLogValue boolValue];
         }
-        if (options[@"autoHandleNotificationDeepLinks"] != nil) {
-            radarOptions.autoHandleNotificationDeepLinks = [options[@"autoHandleNotificationDeepLinks"] boolValue];
+        id autoHandleValue = options[@"autoHandleNotificationDeepLinks"];
+        if (autoHandleValue && autoHandleValue != [NSNull null]) {
+            radarOptions.autoHandleNotificationDeepLinks = [autoHandleValue boolValue];
         }
     }
     [Radar initializeWithPublishableKey:publishableKey options:radarOptions];

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -221,13 +221,13 @@ RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud option
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil) {
-        if (options[@"silentPush"]) {
+        if (options[@"silentPush"] != nil) {
             radarOptions.silentPush = [options[@"silentPush"] boolValue];
         }
-        if (options[@"autoLogNotificationConversions"]) {
+        if (options[@"autoLogNotificationConversions"] != nil) {
             radarOptions.autoLogNotificationConversions = [options[@"autoLogNotificationConversions"] boolValue];
         }
-        if (options[@"autoHandleNotificationDeepLinks"]) {
+        if (options[@"autoHandleNotificationDeepLinks"] != nil) {
             radarOptions.autoHandleNotificationDeepLinks = [options[@"autoHandleNotificationDeepLinks"] boolValue];
         }
     }

--- a/src/@types/RadarNativeInterface.ts
+++ b/src/@types/RadarNativeInterface.ts
@@ -49,7 +49,7 @@ import type {
 } from "./types";
 
 export interface RadarNativeInterface {
-  initialize: (publishableKey: string, fraud?: boolean) => void;
+  initialize: (publishableKey: string, fraud?: boolean, options?: Object | null) => void;
   setLogLevel: (level: RadarLogLevel) => void;
   setUserId: (userId: string) => void;
   getUserId: () => Promise<string>;
@@ -124,7 +124,10 @@ export interface RadarNativeInterface {
   nativeSdkVersion: () => Promise<string>;
   rnSdkVersion: () => string;
   showInAppMessage: (inAppMessage: RadarInAppMessage) => void;
-
+  setPushNotificationToken: (token: string) => void;
+  isInitialized: () => Promise<boolean>;
+  setAppGroup: (groupId: string) => void;
+  setLocationExtensionToken: (token: string) => void;
   onLocationUpdated: (callback: RadarLocationUpdateCallback | null) => void;
   onClientLocationUpdated: (
     callback: RadarClientLocationUpdateCallback | null

--- a/src/NativeRadar.ts
+++ b/src/NativeRadar.ts
@@ -43,7 +43,7 @@ export type InAppMessageClickedEmitter = {
 };
 
 export interface Spec extends TurboModule {
-  initialize(publishableKey: string, fraud: boolean): void;
+  initialize(publishableKey: string, fraud: boolean, options: Object | null): void;
   requestPermissions(background: boolean): Promise<string>;
   getPermissionsStatus(): Promise<string>;
   trackOnce(trackOnceOptions: Object | null): Promise<Object>;
@@ -101,6 +101,10 @@ export interface Spec extends TurboModule {
   getHost(): Promise<string>;
   getPublishableKey(): Promise<string>;
   showInAppMessage(inAppMessage: Object): void;
+  setPushNotificationToken(token: string): void;
+  isInitialized(): Promise<boolean>;
+  setAppGroup(groupId: string): void;
+  setLocationExtensionToken(token: string): void;
   readonly locationEmitter: EventEmitter<LocationEmitter>;
   readonly clientLocationEmitter: EventEmitter<ClientLocationEmitter>;
   readonly errorEmitter: EventEmitter<ErrorEmitter>;

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -1,4 +1,5 @@
 import type { EventSubscription } from "react-native";
+import { Platform } from "react-native";
 import type { RadarNativeInterface } from "./@types/RadarNativeInterface";
 import type {
   RadarTrackCallback,
@@ -118,8 +119,8 @@ let inAppMessageDismissedUpdateSubscription: EventSubscription | null = null;
 let inAppMessageClickedUpdateSubscription: EventSubscription | null = null;
 
 const Radar: RadarNativeInterface = {
-  initialize: (publishableKey: string, fraud?: boolean) => {
-    NativeRadar.initialize(publishableKey, !!fraud);
+  initialize: (publishableKey: string, fraud?: boolean, options?: Object | null) => {
+    NativeRadar.initialize(publishableKey, !!fraud, options || null);
     Radar.onNewInAppMessage((inAppMessage) => {
       Radar.showInAppMessage(inAppMessage);
     });
@@ -316,7 +317,21 @@ const Radar: RadarNativeInterface = {
   showInAppMessage: (inAppMessage: RadarInAppMessage) => {
     return NativeRadar.showInAppMessage(inAppMessage);
   },
-
+  setPushNotificationToken: (token: string) => {
+    if (Platform.OS === 'android') {
+      return NativeRadar.setPushNotificationToken(token);
+    }
+  },
+  setAppGroup: (groupId: string) => {
+    if (Platform.OS === 'ios') {
+      return NativeRadar.setAppGroup(groupId);
+    }
+  },
+  setLocationExtensionToken: (token: string) => {
+    if (Platform.OS === 'ios') {
+      return NativeRadar.setLocationExtensionToken(token);
+    }
+  },
   requestPermissions: (background: boolean) => {
     return NativeRadar.requestPermissions(
       background
@@ -533,6 +548,9 @@ const Radar: RadarNativeInterface = {
   },
   getPublishableKey: function (): Promise<string> {
     return NativeRadar.getPublishableKey();
+  },
+  isInitialized: function (): Promise<boolean> {
+    return NativeRadar.isInitialized();
   },
 };
 

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -318,17 +318,17 @@ const Radar: RadarNativeInterface = {
     return NativeRadar.showInAppMessage(inAppMessage);
   },
   setPushNotificationToken: (token: string) => {
-    if (Platform.OS === 'android') {
+    if (Platform.OS === "android") {
       return NativeRadar.setPushNotificationToken(token);
     }
   },
   setAppGroup: (groupId: string) => {
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === "ios") {
       return NativeRadar.setAppGroup(groupId);
     }
   },
   setLocationExtensionToken: (token: string) => {
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === "ios") {
       return NativeRadar.setLocationExtensionToken(token);
     }
   },


### PR DESCRIPTION
## Summary

Exposes silent push notification methods from the native Radar SDKs to React Native. These methods enable apps to configure silent push for background location updates, manage push tokens on Android, and set up iOS location extensions with app groups. This also extends `initialize()` to forward `RadarInitializeOptions` (including `silentPush`, `autoLogNotificationConversions`, and `autoHandleNotificationDeepLinks`) to the iOS SDK.

## New SDK Components

**`Radar.isInitialized()`** — Returns a `Promise<boolean>` indicating whether the Radar SDK has been initialized. Useful for Android silent push re-initialization logic where you need to check state before re-calling `initialize`.

**`Radar.setPushNotificationToken(token)`** — Sets the FCM push notification token for silent push on Android. No-op on iOS, where push tokens are registered via `AppDelegate`.

**`Radar.setAppGroup(groupId)`** — Sets the app group identifier for sharing data between the main app and iOS location extensions. No-op on Android.

**`Radar.setLocationExtensionToken(token)`** — Sets the token used by the iOS location extension for authenticated background location updates. No-op on Android.

**`Radar.initialize(publishableKey, fraud?, options?)`** — Updated to accept an optional `options` object. On iOS, this forwards `silentPush`, `autoLogNotificationConversions`, and `autoHandleNotificationDeepLinks` to `RadarInitializeOptions`. The options parameter is accepted but currently a no-op on Android.

## How It Works

On **iOS**, `initialize()` now creates a `RadarInitializeOptions` object from the `options` dict and calls `initializeWithPublishableKey:options:` instead of `initializeWithPublishableKey:`. The `setAppGroup` and `setLocationExtensionToken` methods call directly through to their native SDK counterparts. `setPushNotificationToken` is a no-op since iOS handles push registration in `AppDelegate`.

On **Android**, `setPushNotificationToken` calls `Radar.setPushNotificationToken()` to register the FCM token for silent push. `setAppGroup` and `setLocationExtensionToken` are no-ops since those are iOS-specific concepts. The `options` parameter on `initialize` is accepted for API parity but is not yet forwarded to the Android SDK.

Both platforms support `isInitialized()`, which resolves the native SDK's initialization state as a boolean promise.