### PR TITLE
FENCE-2772: Bump map libre to v 11

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | `react` | `>= 16.8.6` | `>= 19.1.0` |
 | `react-native` | `>= 0.60.0` | `>= 0.80.0` |
-| `@maplibre/maplibre-react-native` | `>= 10.2.1` | `>= 11.0.0-beta.10` |
+| `@maplibre/maplibre-react-native` | `>= 10.2.1` | `^11.0.0` |
 
 ### Recommended: `react-native-safe-area-context`
 
@@ -23,7 +23,7 @@ npm install react@^19.1.0 react-native@^0.80.0
 
 2. Upgrade MapLibre React Native:
 ```bash
-npm install @maplibre/maplibre-react-native@^11.0.0-beta.10
+npm install @maplibre/maplibre-react-native@^11.0.0
 ```
 
 3. (Recommended) Install `react-native-safe-area-context` if not already present:

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -143,7 +143,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
     override fun initialize(publishableKey: String, fraud: Boolean, options: ReadableMap?): Unit {
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "4.1.0")
+        editor.putString("x_platform_sdk_version", "4.2.0")
         editor.apply()
 
         Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)
@@ -155,7 +155,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
     override fun initializeWithAuthToken(authToken: String, fraud: Boolean, options: ReadableMap?): Unit {
         val editor = reactApplicationContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit()
         editor.putString("x_platform_sdk_type", "ReactNative")
-        editor.putString("x_platform_sdk_version", "4.1.0")
+        editor.putString("x_platform_sdk_version", "4.2.0")
         editor.apply()
         
         val initOptions = io.radar.sdk.RadarInitializeOptions.builder()

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -102,7 +102,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "4.1.0");
+        editor.putString("x_platform_sdk_version", "4.2.0");
         editor.apply();
         Radar.initialize(getReactApplicationContext(), publishableKey, receiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, inAppMessageReceiver, getCurrentActivity());
         if (fraud) { 
@@ -115,7 +115,7 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
         this.fraud = fraud;
         SharedPreferences.Editor editor = getReactApplicationContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "ReactNative");
-        editor.putString("x_platform_sdk_version", "4.1.0");
+        editor.putString("x_platform_sdk_version", "4.2.0");
         editor.apply();
         
         io.radar.sdk.RadarInitializeOptions.Builder builder = io.radar.sdk.RadarInitializeOptions.builder()

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -861,7 +861,6 @@ export default function App() {
             </Text>
             <Text style={styles.platformText}>Platform: {Platform.OS}</Text>
           </View>
-          {/* The current version of MapLibre does not support the new react native architecture  */}
           {Platform.OS !== "web" && (
             <>
               <View style={{ width: "100%", height: "25%" }}>

--- a/example/app.json
+++ b/example/app.json
@@ -22,7 +22,7 @@
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "This app needs location.",
         "NSLocationAlwaysAndWhenInUseUsageDescription": "This app needs location."
-      }
+      },
     },
     "android": {
       "adaptiveIcon": {

--- a/example/app.json
+++ b/example/app.json
@@ -22,7 +22,7 @@
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "This app needs location.",
         "NSLocationAlwaysAndWhenInUseUsageDescription": "This app needs location."
-      },
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",
-        "@maplibre/maplibre-react-native": "11.0.0-beta.10",
+        "@maplibre/maplibre-react-native": "^11.0.0",
         "expo": "^54.0.0",
         "expo-build-properties": "~1.0.9",
         "expo-status-bar": "~3.0.8",
@@ -27,8 +27,7 @@
       }
     },
     "..": {
-      "version": "4.0.0",
-      "extraneous": true,
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -65,7 +64,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@maplibre/maplibre-react-native": ">=11.0.0-beta.10",
+        "@maplibre/maplibre-react-native": "^11.0.0",
         "expo": ">=43.0.5",
         "react": ">= 19.1.0",
         "react-native": ">= 0.80.0",
@@ -2739,9 +2738,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.4.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.4.1.tgz",
-      "integrity": "sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -2759,16 +2758,12 @@
       }
     },
     "node_modules/@maplibre/maplibre-react-native": {
-      "version": "11.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-11.0.0-beta.10.tgz",
-      "integrity": "sha512-+4fonzWqa7oINRJ4NlcgPVPdxi/+w2tyNO6n5oZ5B+H0NRg92/ou+EdSBbP/Q3KA7XhCc9U2lP89HsEBt1nO+w==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-11.0.0.tgz",
+      "integrity": "sha512-OCds0j9+1kKkx0B5DikMpYvrzCwYv3ti5j9K0eQadq/M0RjQ40CFUdVpi4N0DtZXZxThmnMI5huqArN6G9GmHw==",
       "license": "MIT",
-      "workspaces": [
-        "docs",
-        "examples/*"
-      ],
       "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "24.4.1",
+        "@maplibre/maplibre-gl-style-spec": "24.8.1",
         "@turf/distance": "^7.1.0",
         "@turf/helpers": "^7.1.0",
         "@turf/length": "^7.1.0",
@@ -6726,12 +6721,6 @@
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "license": "ISC"
     },
-    "node_modules/radar-sdk-js": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6852,31 +6841,8 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "4.1.0",
-      "resolved": "file:..",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "radar-sdk-js": "^3.7.1"
-      },
-      "peerDependencies": {
-        "@maplibre/maplibre-react-native": ">=11.0.0-beta.10",
-        "expo": ">=43.0.5",
-        "react": ">= 19.1.0",
-        "react-native": ">= 0.80.0",
-        "react-native-safe-area-context": "^5.6.2"
-      },
-      "peerDependenciesMeta": {
-        "@maplibre/maplibre-react-native": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        },
-        "react-native-safe-area-context": {
-          "optional": true
-        }
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.2",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6848,7 +6848,7 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "resolved": "file:..",
       "license": "Apache-2.0",
       "dependencies": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -28,6 +28,7 @@
     },
     "..": {
       "version": "4.1.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -6721,6 +6722,12 @@
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "license": "ISC"
     },
+    "node_modules/radar-sdk-js": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
+      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6841,8 +6848,31 @@
       }
     },
     "node_modules/react-native-radar": {
-      "resolved": "..",
-      "link": true
+      "version": "4.1.0",
+      "resolved": "file:..",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "radar-sdk-js": "^3.7.1"
+      },
+      "peerDependencies": {
+        "@maplibre/maplibre-react-native": "^11.0.0",
+        "expo": ">=43.0.5",
+        "react": ">= 19.1.0",
+        "react-native": ">= 0.80.0",
+        "react-native-safe-area-context": "^5.6.2"
+      },
+      "peerDependenciesMeta": {
+        "@maplibre/maplibre-react-native": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        },
+        "react-native-safe-area-context": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.2",

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
-    "@maplibre/maplibre-react-native": "11.0.0-beta.10",
+    "@maplibre/maplibre-react-native": "^11.0.0",
     "expo": "^54.0.0",
     "expo-build-properties": "~1.0.9",
     "expo-status-bar": "~3.0.8",

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -217,7 +217,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud options:(NSDictionary *)options) {
     _publishableKey = publishableKey; 
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"4.1.0" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"4.2.0" forKey:@"radar-xPlatformSDKVersion"];
     
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil) {
@@ -240,7 +240,7 @@ RCT_EXPORT_METHOD(initialize:(NSString *)publishableKey fraud:(BOOL)fraud option
 RCT_EXPORT_METHOD(initializeWithAuthToken:(NSString *)authToken fraud:(BOOL)fraud options:(NSDictionary *)options) {
     _publishableKey = nil;
     [[NSUserDefaults standardUserDefaults] setObject:@"ReactNative" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"4.1.0" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"4.2.0" forKey:@"radar-xPlatformSDKVersion"];
     RadarInitializeOptions *radarOptions = [[RadarInitializeOptions alloc] init];
     if (options != nil) {
         id silentPushValue = options[@"silentPush"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@maplibre/maplibre-react-native": ">=11.0.0-beta.10",
+        "@maplibre/maplibre-react-native": "^11.0.0",
         "expo": ">=43.0.5",
         "react": ">= 19.1.0",
         "react-native": ">= 0.80.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-radar",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-radar",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     ]
   },
   "peerDependencies": {
-    "@maplibre/maplibre-react-native": ">=11.0.0-beta.10",
+    "@maplibre/maplibre-react-native": "^11.0.0",
     "expo": ">=43.0.5",
     "react": ">= 19.1.0",
     "react-native": ">= 0.80.0",

--- a/src/@types/maplibre-react-native.d.ts
+++ b/src/@types/maplibre-react-native.d.ts
@@ -1,16 +1,3 @@
 declare module "@maplibre/maplibre-react-native" {
-  export interface MapRef {
-    getCenter(): Promise<{ lng: number; lat: number }>;
-    getZoom(): Promise<number>;
-    getBearing(): Promise<number>;
-    getPitch(): Promise<number>;
-    getBounds(): Promise<{ ne: [number, number]; sw: [number, number] }>;
-    project(coordinate: [number, number]): Promise<{ x: number; y: number }>;
-    unproject(point: { x: number; y: number }): Promise<[number, number]>;
-    queryRenderedFeatures(
-      point: [number, number] | [[number, number], [number, number]],
-      filter?: string[],
-      layerIDs?: string[],
-    ): Promise<GeoJSON.FeatureCollection>;
-  }
+  export interface MapRef {}
 }

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { Platform } from "react-native";
+import { Platform, type NativeSyntheticEvent } from "react-native";
 import type { MapRef } from "@maplibre/maplibre-react-native";
 const platform = Platform.OS;
 
@@ -908,15 +908,15 @@ export interface RadarMapOptions {
   showUserLocation?: boolean;
   mapRef?: React.Ref<MapRef>;
   onRegionDidChange?: (event: RadarMapRegionChangeEvent) => void;
-  onDidFinishLoadingMap?: () => void;
-  onWillStartLoadingMap?: () => void;
-  onDidFailLoadingMap?: () => void;
+  onDidFinishLoadingMap?: (event?: NativeSyntheticEvent<null>) => void;
+  onWillStartLoadingMap?: (event?: NativeSyntheticEvent<null>) => void;
+  onDidFailLoadingMap?: (event?: NativeSyntheticEvent<null>) => void;
 }
 
 export interface RadarMapRegionChangeEvent {
   center: [number, number];
   zoom: number;
-  bounds?: [[number, number], [number, number]];
+  bounds?: [number, number, number, number];
   bearing?: number;
   pitch?: number;
   animated: boolean;

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -908,15 +908,19 @@ export interface RadarMapOptions {
   showUserLocation?: boolean;
   mapRef?: React.Ref<MapRef>;
   onRegionDidChange?: (event: RadarMapRegionChangeEvent) => void;
-  onDidFinishLoadingMap?: (event?: NativeSyntheticEvent<null>) => void;
-  onWillStartLoadingMap?: (event?: NativeSyntheticEvent<null>) => void;
-  onDidFailLoadingMap?: (event?: NativeSyntheticEvent<null>) => void;
+  onDidFinishLoadingMap?: (event: NativeSyntheticEvent<null>) => void;
+  onWillStartLoadingMap?: (event: NativeSyntheticEvent<null>) => void;
+  onDidFailLoadingMap?: (event: NativeSyntheticEvent<null>) => void;
 }
 
 export interface RadarMapRegionChangeEvent {
   center: [number, number];
   zoom: number;
-  bounds?: [number, number, number, number];
+  /**
+  * Geographic bounds in `[west, south, east, north]` order (south-west corner
+  * then north-east corner, per GeoJSON RFC 7946).
+  */
+  bounds?: [west: number, south: number, east: number, north: number];
   bearing?: number;
   pitch?: number;
   animated: boolean;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // This file contains the version of the react-native-radar package
 // It should be updated to match the version in package.json
-export const VERSION = '4.1.0';
+export const VERSION = '4.2.0';


### PR DESCRIPTION
- Bumps map-libre dependency to `11.0.0` 
- Updates map types to match map-libre
- Removes `mapRef` stubs 
- Bumps sdk version to `4.2.0`