### PR TITLE
FENCE-2893: Send `X-Radar-Mobile-Origin` on `RadarMap` requests to support mobile app restrictions

### DIFF
--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -456,6 +456,10 @@ class RadarModule(reactContext: ReactApplicationContext) :
         radarModuleImpl.getPublishableKey(promise)
     }
 
+    override fun getMobileOrigin(promise: Promise): Unit {
+        promise.resolve(reactApplicationContext.packageName)
+    }
+
     override fun showInAppMessage(inAppMessage: ReadableMap): Unit {
         radarModuleImpl.showInAppMessage(inAppMessage)
     }

--- a/android/src/oldarch/java/com/radar/RadarModule.java
+++ b/android/src/oldarch/java/com/radar/RadarModule.java
@@ -475,6 +475,14 @@ public class RadarModule extends ReactContextBaseJavaModule implements Permissio
     }
 
     @ReactMethod
+    public void getMobileOrigin(final Promise promise) {
+        if (promise == null) {
+            return;
+        }
+        promise.resolve(getReactApplicationContext().getPackageName());
+    }
+
+    @ReactMethod
     public void showInAppMessage(ReadableMap inAppMessageMap) {
         radarModuleImpl.showInAppMessage(inAppMessageMap);
     }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -28,7 +28,6 @@
     },
     "..": {
       "version": "4.32.0",
-      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -6721,12 +6720,6 @@
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "license": "ISC"
     },
-    "node_modules/radar-sdk-js": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.7.1.tgz",
-      "integrity": "sha512-yhuvEfyOeOEZpPf9XGOaC/TZlf3iib6iCcvZnwHR+fRV6r5f4/BIEO9xcEiU0WF/sl7pA22Vx4KXi8vsfBrstg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6847,31 +6840,8 @@
       }
     },
     "node_modules/react-native-radar": {
-      "version": "4.32.0",
-      "resolved": "file:..",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "radar-sdk-js": "^3.7.1"
-      },
-      "peerDependencies": {
-        "@maplibre/maplibre-react-native": "^11.0.0",
-        "expo": ">=43.0.5",
-        "react": ">= 19.1.0",
-        "react-native": ">= 0.80.0",
-        "react-native-safe-area-context": "^5.6.2"
-      },
-      "peerDependenciesMeta": {
-        "@maplibre/maplibre-react-native": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        },
-        "react-native-safe-area-context": {
-          "optional": true
-        }
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.2",

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -335,6 +335,10 @@ RCT_EXPORT_METHOD(getPublishableKey:(RCTPromiseResolveBlock)resolve reject:(RCTP
     resolve(_publishableKey);
 }
 
+RCT_EXPORT_METHOD(getMobileOrigin:(RCTPromiseResolveBlock) resolve reject:(RCTPromiseRejectBlock)reject) {
+    resolve([[NSBundle mainBundle] bundleIdentifier]);
+}
+
 RCT_EXPORT_METHOD(getPermissionsStatus:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
     NSString *statusStr;

--- a/src/@types/RadarNativeInterface.ts
+++ b/src/@types/RadarNativeInterface.ts
@@ -147,4 +147,5 @@ export interface RadarNativeInterface {
   onInAppMessageClicked: (callback: RadarInAppMessageClickedCallback | null) => void;
   getHost: () => Promise<string>;
   getPublishableKey: () => Promise<string>;
+  getMobileOrigin: () => Promise<string>;
 }

--- a/src/NativeRadar.ts
+++ b/src/NativeRadar.ts
@@ -103,6 +103,7 @@ export interface Spec extends TurboModule {
   nativeSdkVersion(): Promise<string>;
   getHost(): Promise<string>;
   getPublishableKey(): Promise<string>;
+  getMobileOrigin(): Promise<string>;
   showInAppMessage(inAppMessage: Object): void;
   setPushNotificationToken(token: string): void;
   isInitialized(): Promise<boolean>;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,4 +8,8 @@ const getPublishableKey = () => (
   Radar.getPublishableKey()
 );
 
-export { getHost, getPublishableKey };
+const getMobileOrigin = () => (
+  Radar.getMobileOrigin()
+);
+
+export { getHost, getPublishableKey, getMobileOrigin };

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -570,6 +570,9 @@ const Radar: RadarNativeInterface = {
   getPublishableKey: function (): Promise<string> {
     return NativeRadar.getPublishableKey();
   },
+  getMobileOrigin: function (): Promise<string> {
+    return NativeRadar.getMobileOrigin();
+  },
   isInitialized: function (): Promise<boolean> {
     return NativeRadar.isInitialized();
   },

--- a/src/ui/map.jsx
+++ b/src/ui/map.jsx
@@ -1,23 +1,26 @@
 import React, { useState, useEffect } from 'react';
 import { View, Image } from 'react-native';
 import Radar from '../index.native';
-import { getHost, getPublishableKey } from '../helpers';
+import { getHost, getPublishableKey, getMobileOrigin } from '../helpers';
 import styles from './styles';
 
 let MapLibreGL;
 let MapLibreMap;
 let GeoJSONSource;
 let Layer;
+let TransformRequestManager;
 try {
   MapLibreGL = require('@maplibre/maplibre-react-native');
   MapLibreMap = MapLibreGL.Map;
   GeoJSONSource = MapLibreGL.GeoJSONSource;
   Layer = MapLibreGL.Layer;
+  TransformRequestManager = MapLibreGL.TransformRequestManager;
 } catch (e) {
   MapLibreGL = null;
   MapLibreMap = null;
   GeoJSONSource = null;
   Layer = null;
+  TransformRequestManager = null;
 }
 
 const DEFAULT_STYLE = 'radar-default-v1';
@@ -49,10 +52,35 @@ const RadarMap = ({ mapOptions, children }) => {
   const [userLocation, setUserLocation] = useState(null);
 
   useEffect(() => {
-    createStyleURL(mapOptions?.mapStyle || DEFAULT_STYLE).then((result) => {
+    const setup = async () => {
+      const host = await getHost();
+
+      if (TransformRequestManager) {
+        try {
+          const mobileOrigin = await getMobileOrigin();
+          if (mobileOrigin) {
+            const mapHostPattern = `${host
+              .replace(/^https?:\/\//, '')
+              .replace(/\./g, '\\.')}/maps/`;
+            TransformRequestManager.addHeader({
+              id: 'radar-mobile-origin',
+              name: 'X-Radar-Mobile-Origin',
+              value: mobileOrigin,
+              match: mapHostPattern,
+            });
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(`Radar SDK: Failed to set mobile origin header: ${err}`);
+        }
+      }
+
+      const result = await createStyleURL(mapOptions?.mapStyle || DEFAULT_STYLE);
       setStyleURL(result);
-    });
-  }, [mapOptions]);
+    };
+
+    setup();
+  }, [mapOptions?.mapStyle]);
 
   useEffect(() => {
     Radar.getLocation().then((result) => {


### PR DESCRIPTION
## Summary

`RadarMap` tiles/styles are fetched directly by MapLibre, bypassing the native SDK's networking. As a result, those requests never carried the iOS bundle ID / Android package name that mobile app restrictions validate against. When a project had **both** website restrictions and mobile restrictions enabled, the maps API required a request to match an allowed web origin *or* mobile ID — and the MapLibre requests sent neither, so they were rejected (401) and the map failed to load. Normal SDK calls (e.g. tracking) were unaffected because they already send `X-Radar-Mobile-Origin`.

This PR makes `RadarMap` attach `X-Radar-Mobile-Origin` (the app's bundle ID / package name) to all Radar maps requests so they satisfy mobile restrictions.

## Changes

- Added a native `getMobileOrigin()` method that returns the iOS bundle identifier / Android package name. The same value the native SDK sends as `X-Radar-Mobile-Origin`. 
- `map.jsx`: register an `X-Radar-Mobile-Origin` header via MapLibre's `TransformRequestManager.addHeader`, scoped (via `match`) to the Radar maps host so it's only sent to `api.radar.io/maps/` and not to any third-party tile sources.

## Testing

- **Server contract (curl):** against a live project with both website + mobile restrictions:
  - no header → `401`
  - `-H "X-Radar-Mobile-Origin: <bundleId>"` → `200`
- **On-device (iOS + Android):** example app with the restricted live key:
  - both restrictions + correct bundle ID/package name → map loads
  - incorrect/removed mobile ID → map fails (confirms enforcement, not bypass)
  - no restrictions → map loads (regression check)
  - tracking continues to work