### PR TITLE
FENCE-3003: Fix Expo plugin overwriting iOS background modes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
       - run:
           name: Type-check
           command: npm run build-all
+      - run:
+          name: Test Expo background modes
+          command: npm run test:expo-background-modes
       - persist_to_workspace:
           root: ~/react-native-radar
           paths:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check-latest-tag": "node ./scripts/check-latest-tag.cjs",
     "check-beta-tag": "node ./scripts/check-beta-tag.cjs",
     "build-plugin": "tsc --build plugin/",
+    "test:expo-background-modes": "npm run build-plugin && node --test scripts/tests/expo-background-modes.test.cjs",
     "build": "tsc",
     "setup": "npm rebuild fsevents --ignore-scripts=false"
   },

--- a/plugin/src/withRadarIOS.ts
+++ b/plugin/src/withRadarIOS.ts
@@ -192,7 +192,11 @@ export const withRadarIOS = (config: any, args: RadarPluginProps) => {
         args.iosNSLocationAlwaysAndWhenInUseUsageDescription; 
     }
     if (args.iosBackgroundMode) {
-      config.modResults.UIBackgroundModes = ["location", "fetch"];
+      config.modResults.UIBackgroundModes = Array.from(new Set([
+        ...(config.modResults.UIBackgroundModes ?? []),
+        "location",
+        "fetch",
+      ]));
     }
     if (args.iosFraud) {
       config.modResults.NSAppTransportSecurity = {

--- a/scripts/tests/expo-background-modes.test.cjs
+++ b/scripts/tests/expo-background-modes.test.cjs
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { test } = require('node:test');
+const { compileModsAsync } = require('expo/config-plugins');
+const { withRadarIOS } = require('../../plugin/build/withRadarIOS');
+
+for (const { name, modes, enabled, expected } of [
+  {
+    name: 'preserves notification and other app background modes',
+    modes: ['location', 'remote-notification', 'fetch', 'audio'],
+    enabled: true,
+    expected: ['location', 'remote-notification', 'fetch', 'audio'],
+  },
+  {
+    name: 'adds required modes without duplicating existing location',
+    modes: ['remote-notification', 'location'],
+    enabled: true,
+    expected: ['remote-notification', 'location', 'fetch'],
+  },
+  {
+    name: 'adds required modes when none are configured',
+    enabled: true,
+    expected: ['location', 'fetch'],
+  },
+  {
+    name: 'leaves configured modes alone when disabled',
+    modes: ['remote-notification'],
+    enabled: false,
+    expected: ['remote-notification'],
+  },
+]) {
+  test(name, async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'radar-background-modes-'));
+    try {
+      const config = withRadarIOS({
+        name: 'BackgroundModesTest',
+        slug: 'background-modes-test',
+        ios: { infoPlist: modes ? { UIBackgroundModes: modes } : {} },
+      }, { iosBackgroundMode: enabled });
+      const result = await compileModsAsync(config, {
+        projectRoot,
+        platforms: ['ios'],
+        introspect: true,
+      });
+      assert.deepEqual(result.ios.infoPlist.UIBackgroundModes, expected);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
Enabling `iosBackgroundMode` in the Expo plugin overwrote app-configured background modes, removing `remote-notification` from the generated Info.plist. Preserve existing modes and add `location` and `fetch` without duplicates.

Fixes #378.

## Test Plan
- In an Expo app's app.json, set `expo.ios.infoPlist.UIBackgroundModes` to `["location", "remote-notification", "fetch"]` and enable `iosBackgroundMode` in the Radar plugin options.
- Generate the iOS project with Expo prebuild and open the app's Info.plist. Confirm all three background modes remain and each appears once.
- Disable `iosBackgroundMode`, generate the iOS project again, and confirm the app-configured modes remain unchanged.

## Validation
- The existing CircleCI `node` job now runs `npm run test:expo-background-modes` after the plugin build, before the dependent native build jobs.
- `npm run test:expo-background-modes` passed all four checks, covering preservation, missing defaults, duplicate prevention, and the disabled option. The two preservation checks failed against the previous plugin build.
- Expo 54.0.11 prebuild with `--platform ios --clean --no-install` preserved all three modes in the generated Info.plist after the fix.
- `git diff --check` passed. No native app build or device testing was needed for this config-generation change.
