### PR TITLE
fix(android): queue TurboModule startup events until listeners are ready

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "com.vaadin.external.google:android-json:0.0.20131108.vaadin1"
   // Expose React Native to consumers of this module
   api "com.facebook.react:react-android"
 

--- a/android/src/main/java/com/radar/EventPayload.kt
+++ b/android/src/main/java/com/radar/EventPayload.kt
@@ -1,0 +1,34 @@
+package com.radar
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal object EventPayload {
+    // Match RadarUtils before saving, so JSON does not change which fields JS receives.
+    fun snapshot(value: JSONObject): String = copyObject(value, false).toString()
+
+    // JSON can turn a whole-number Double into a Long, which RadarUtils skips.
+    fun restore(value: String): JSONObject = copyObject(JSONObject(value), true)
+
+    private fun copyObject(value: JSONObject, restoring: Boolean): JSONObject {
+        val result = JSONObject()
+        value.keys().forEach { key ->
+            copyValue(value.get(key), restoring, false)?.let { result.put(key, it) }
+        }
+        return result
+    }
+
+    private fun copyValue(value: Any, restoring: Boolean, inArray: Boolean): Any? =
+        when (value) {
+            is JSONObject -> copyObject(value, restoring)
+            is JSONArray -> JSONArray().apply {
+                for (index in 0 until value.length()) {
+                    copyValue(value.get(index), restoring, true)?.let { put(it) }
+                }
+            }
+            is String, is Boolean, is Int, is Double -> value
+            is Float -> if (inArray) null else value.toString().toDouble()
+            is Long -> if (restoring) value.toDouble() else null
+            else -> null
+        }
+}

--- a/android/src/main/java/com/radar/StartupEventQueue.kt
+++ b/android/src/main/java/com/radar/StartupEventQueue.kt
@@ -1,0 +1,86 @@
+package com.radar
+
+internal class StartupEventQueue(
+    private val maxEntries: Int = 256,
+    private val maxBytes: Int = 1024 * 1024,
+) {
+    data class Event(val name: String, val payload: String) {
+        val bytes = payload.toByteArray(Charsets.UTF_8).size
+    }
+
+    private val events = mutableListOf<Event>()
+    private val listeners = mutableMapOf<String, Int>()
+    private var bytes = 0
+    private var startup = true
+    private var tracking = false
+    private var initialized = false
+    private var emitterReady = false
+    private var owner = false
+    private var closed = false
+    private var accepting = true
+
+    // The module shares this lock with teardown so an emit cannot outlive its owner.
+    val lock = Any()
+
+    fun claim() = synchronized(lock) { if (!closed) owner = true }
+    fun beginInitialization() = synchronized(lock) {
+        initialized = false
+        accepting = !closed
+    }
+    fun abortInitialization() = synchronized(lock) {
+        initialized = false
+        owner = false
+        accepting = false
+        events.clear()
+        bytes = 0
+    }
+    fun initialized() = synchronized(lock) {
+        initialized = true
+        finishStartup()
+    }
+    fun emitterReady() = synchronized(lock) {
+        emitterReady = true
+        finishStartup()
+    }
+    private fun finishStartup() {
+        if (initialized && emitterReady) startup = false
+    }
+    fun listenerCount(name: String, count: Int) = synchronized(lock) {
+        tracking = true
+        listeners[name] = count.coerceAtLeast(0)
+    }
+
+    // Strings keep SDK objects and mutable React Native maps out of the backlog.
+    fun submit(name: String, payload: String): Boolean = synchronized(lock) {
+        if (closed || !accepting || (!startup && tracking && (listeners[name] ?: 0) == 0)) return false
+        val event = Event(name, payload)
+        if (event.bytes > maxBytes) return true
+        var overflow = false
+        while (events.isNotEmpty() && (events.size >= maxEntries || bytes + event.bytes > maxBytes)) {
+            bytes -= events.removeAt(0).bytes
+            overflow = true
+        }
+        events.add(event)
+        bytes += event.bytes
+        overflow
+    }
+
+    fun drain(emit: (Event) -> Unit) = synchronized(lock) {
+        if (closed || !owner || !initialized || !emitterReady) return
+        while (!closed && owner && initialized && emitterReady) {
+            val index = events.indexOfFirst { !tracking || (listeners[it.name] ?: 0) > 0 }
+            if (index < 0) break
+            val event = events.removeAt(index)
+            bytes -= event.bytes
+            emit(event)
+        }
+    }
+
+    fun close() = synchronized(lock) {
+        closed = true
+        owner = false
+        events.clear()
+        listeners.clear()
+        bytes = 0
+    }
+}

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -29,120 +29,153 @@ import io.radar.sdk.RadarNotificationOptions
 import io.radar.sdk.RadarInAppMessageReceiver
 import android.content.Context
 import android.location.Location
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.CxxCallbackImpl
-import org.json.JSONException
 import org.json.JSONObject
 
 @ReactModule(name = RadarModule.NAME)
 class RadarModule(reactContext: ReactApplicationContext) :
     NativeRadarSpec(reactContext), PermissionListener {
-    private val receiverOwner = Any()
-
-    @Volatile
+    private val eventQueue = StartupEventQueue()
+    private val drainHandler = android.os.Handler(android.os.Looper.getMainLooper())
     private var isInvalidated = false
-    @Volatile
-    private var jsEventEmitterReady = false
-    private var receiverAttachmentPending = false
-    private var receiverAttachmentFraud = false
-    private var initializationInProgress = false
+    private var drainScheduled = false
+    private var lastOverflowWarning = Long.MIN_VALUE
+    private val drainRunnable = Runnable {
+        synchronized(eventQueue.lock) {
+            drainScheduled = false
+            eventQueue.drain { event ->
+                val payload = RadarUtils.mapForJson(EventPayload.restore(event.payload))
+                when (event.name) {
+                    "eventsEmitter" -> emitEventsEmitter(payload)
+                    "locationEmitter" -> emitLocationEmitter(payload)
+                    "clientLocationEmitter" -> emitClientLocationEmitter(payload)
+                    "errorEmitter" -> emitErrorEmitter(payload)
+                    "logEmitter" -> emitLogEmitter(payload)
+                    "newInAppMessageEmitter" -> emitNewInAppMessageEmitter(payload)
+                    "inAppMessageDismissedEmitter" -> emitInAppMessageDismissedEmitter(payload)
+                    "inAppMessageClickedEmitter" -> emitInAppMessageClickedEmitter(payload)
+                    "tokenEmitter" -> emitTokenEmitter(payload)
+                }
+            }
+        }
+    }
 
     override fun setEventEmitterCallback(eventEmitterCallback: CxxCallbackImpl) {
-        super.setEventEmitterCallback(eventEmitterCallback)
-        jsEventEmitterReady = true
-        synchronized(receiverLock) {
-            attachReceiversIfReadyLocked()
+        synchronized(eventQueue.lock) {
+            if (isInvalidated) return
+            super.setEventEmitterCallback(eventEmitterCallback)
+            eventQueue.emitterReady()
+            scheduleDrain()
+        }
+    }
+
+    override fun _setEventListenerCount(eventName: String, count: Double) {
+        synchronized(eventQueue.lock) {
+            if (isInvalidated) return
+            eventQueue.listenerCount(eventName, count.toInt())
+            scheduleDrain()
+        }
+    }
+
+    private fun scheduleDrain() {
+        if (!drainScheduled) {
+            drainScheduled = drainHandler.post(drainRunnable)
+        }
+    }
+
+    private fun submit(name: String, payload: JSONObject) {
+        synchronized(eventQueue.lock) {
+            if (isInvalidated) return
+            if (eventQueue.submit(name, EventPayload.snapshot(payload))) {
+                val now = android.os.SystemClock.elapsedRealtime()
+                if (lastOverflowWarning == Long.MIN_VALUE || now - lastOverflowWarning >= 60000) {
+                    lastOverflowWarning = now
+                    Log.w(TAG, "Startup event queue limit reached; some events were discarded")
+                }
+            }
+            scheduleDrain()
         }
     }
 
     private val radarReceiver = object : RadarReceiver() {
         override fun onEventsReceived(context: Context, events: Array<RadarEvent>, user: RadarUser?) {
-            if (isInvalidated || !jsEventEmitterReady) return
-            val eventBlob = Arguments.createMap().apply {
-                var eventsArray = Arguments.createArray()
+            val eventBlob = JSONObject().apply {
+                val eventsArray = org.json.JSONArray()
                 for (event in events) {
-                    eventsArray.pushMap(RadarUtils.mapForJson(event.toJson()))
+                    eventsArray.put(event.toJson())
                 }
-                putArray("events", eventsArray)
+                put("events", eventsArray)
                 if (user != null) {
-                    putMap("user", RadarUtils.mapForJson(user.toJson()))
+                    put("user", user.toJson())
                 }
             }
-            emitIfActive { emitEventsEmitter(eventBlob) }
+            submit("eventsEmitter", eventBlob)
         }
 
         override fun onLocationUpdated(context: Context, location: Location, user: RadarUser) {
-            if (isInvalidated || !jsEventEmitterReady) return
-            val eventBlob = Arguments.createMap().apply {
-                putString("location", Radar.jsonForLocation(location).toString())
-                putString("user", user.toJson().toString())
+            val eventBlob = JSONObject().apply {
+                put("location", Radar.jsonForLocation(location).toString())
+                put("user", user.toJson().toString())
             }
-            emitIfActive { emitLocationEmitter(eventBlob) }
+            submit("locationEmitter", eventBlob)
         }
 
         override fun onClientLocationUpdated(context: Context, location: Location, stopped: Boolean, source: Radar.RadarLocationSource) {
-            if (isInvalidated || !jsEventEmitterReady) return
-            val eventBlob = Arguments.createMap().apply {
-                putString("location", Radar.jsonForLocation(location).toString())
-                putBoolean("stopped", stopped)
-                putString("source", source.toString())
+            val eventBlob = JSONObject().apply {
+                put("location", Radar.jsonForLocation(location).toString())
+                put("stopped", stopped)
+                put("source", source.toString())
             }
-            emitIfActive { emitClientLocationEmitter(eventBlob) }
+            submit("clientLocationEmitter", eventBlob)
         }
 
         override fun onError(context: Context, status: Radar.RadarStatus) {
-            if (isInvalidated || !jsEventEmitterReady) return
-            val eventBlob = Arguments.createMap().apply {
-                putString("status", status.toString())
+            val eventBlob = JSONObject().apply {
+                put("status", status.toString())
             }
-            emitIfActive { emitErrorEmitter(eventBlob) }
+            submit("errorEmitter", eventBlob)
         }
 
         override fun onLog(context: Context, message: String) {
-            if (isInvalidated || !jsEventEmitterReady) return
-            val eventBlob = Arguments.createMap().apply {
-                putString("message", message)
+            val eventBlob = JSONObject().apply {
+                put("message", message)
             }
-            emitIfActive { emitLogEmitter(eventBlob) }
+            submit("logEmitter", eventBlob)
         }
     }
 
     private val radarInAppMessageReceiver = object : RadarInAppMessageReceiver {
         override fun onNewInAppMessage(message: RadarInAppMessage) {
-            if (isInvalidated || !jsEventEmitterReady) return
             try {
-                val eventBlob = Arguments.createMap().apply {
-                    putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
+                val eventBlob = JSONObject().apply {
+                    put("inAppMessage", JSONObject(message.toJson()))
                 }
-                emitIfActive { emitNewInAppMessageEmitter(eventBlob) }
+                submit("newInAppMessageEmitter", eventBlob)
             } catch (e: Exception) {
                 Log.e(TAG, "Exception", e)
             }
         }
 
         override fun onInAppMessageDismissed(message: RadarInAppMessage) {
-            if (isInvalidated || !jsEventEmitterReady) return
             try {
-                val eventBlob = Arguments.createMap().apply {
-                    putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
+                val eventBlob = JSONObject().apply {
+                    put("inAppMessage", JSONObject(message.toJson()))
                 }
-                emitIfActive { emitInAppMessageDismissedEmitter(eventBlob) }
+                submit("inAppMessageDismissedEmitter", eventBlob)
             } catch (e: Exception) {
                 Log.e(TAG, "Exception", e)
             }
         }
 
         override fun onInAppMessageButtonClicked(message: RadarInAppMessage) {
-            if (isInvalidated || !jsEventEmitterReady) return
             try {
-                val eventBlob = Arguments.createMap().apply {
-                    putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
+                val eventBlob = JSONObject().apply {
+                    put("inAppMessage", JSONObject(message.toJson()))
                 }
-                emitIfActive { emitInAppMessageClickedEmitter(eventBlob) }
+                submit("inAppMessageClickedEmitter", eventBlob)
             } catch (e: Exception) {
                 Log.e(TAG, "Exception", e)
             }
@@ -151,11 +184,10 @@ class RadarModule(reactContext: ReactApplicationContext) :
 
     private val radarVerifiedReceiver = object : RadarVerifiedReceiver() {
         override fun onTokenUpdated(context: Context, token: RadarVerifiedLocationToken) {
-            if (isInvalidated || !jsEventEmitterReady) return
-            val eventBlob = Arguments.createMap().apply {
-                putString("token", token.toJson().toString())
+            val eventBlob = JSONObject().apply {
+                put("token", token.toJson().toString())
             }
-            emitIfActive { emitTokenEmitter(eventBlob) }
+            submit("tokenEmitter", eventBlob)
         }
     }
 
@@ -167,19 +199,23 @@ class RadarModule(reactContext: ReactApplicationContext) :
         return NAME
     }
 
-    override fun invalidate() {
-        isInvalidated = true
-        jsEventEmitterReady = false
+    private fun closeQueue() {
+        synchronized(eventQueue.lock) {
+            isInvalidated = true
+            eventQueue.close()
+            drainHandler.removeCallbacks(drainRunnable)
+            drainScheduled = false
+        }
+    }
 
+    override fun invalidate() {
+        closeQueue()
         synchronized(receiverLock) {
-            receiverAttachmentPending = false
-            initializationInProgress = false
-            if (activeReceiverOwner === receiverOwner) {
+            if (activeReceiverOwner === this) {
                 detachReceiversLocked()
                 activeReceiverOwner = null
             }
         }
-
         super.invalidate()
     }
 
@@ -193,11 +229,11 @@ class RadarModule(reactContext: ReactApplicationContext) :
             Radar.initialize(
                 reactApplicationContext,
                 publishableKey,
-                null,
+                radarReceiver,
                 Radar.RadarLocationServicesProvider.GOOGLE,
                 fraud,
                 null,
-                null,
+                radarInAppMessageReceiver,
                 currentActivity
             )
         }
@@ -211,6 +247,8 @@ class RadarModule(reactContext: ReactApplicationContext) :
         
         val initOptions = io.radar.sdk.RadarInitializeOptions.builder()
             .authToken(authToken)
+            .radarReceiver(radarReceiver)
+            .inAppMessageReceiver(radarInAppMessageReceiver)
             .locationProvider(Radar.RadarLocationServicesProvider.GOOGLE)
             .fraud(fraud)
             .apply { currentActivity?.let { activity(it) } }
@@ -221,50 +259,53 @@ class RadarModule(reactContext: ReactApplicationContext) :
     }
 
     private fun initializeRadar(fraud: Boolean, initialize: () -> Unit) {
+        // SDK calls can send events from another thread, so they cannot hold the queue lock.
         synchronized(receiverLock) {
-            if (activeReceiverOwner != null) {
-                detachReceiversLocked()
+            synchronized(eventQueue.lock) {
+                if (isInvalidated) return
             }
-            activeReceiverOwner = receiverOwner
-            receiverAttachmentPending = true
-            receiverAttachmentFraud = fraud
-            initializationInProgress = true
-
+            if (activeReceiverOwner !== this) {
+                activeReceiverOwner?.closeQueue()
+                if (activeReceiverOwner != null) detachReceiversLocked()
+                activeReceiverOwner = this
+            }
+            eventQueue.claim()
+            eventQueue.beginInitialization()
             try {
                 initialize()
-                initializationInProgress = false
-                attachReceiversIfReadyLocked()
+                synchronized(eventQueue.lock) {
+                    if (isInvalidated) {
+                        detachReceiversLocked()
+                        activeReceiverOwner = null
+                        return
+                    }
+                }
+                Radar.setReceiver(radarReceiver)
+                Radar.setInAppMessageReceiver(radarInAppMessageReceiver)
+                try {
+                    Radar.setVerifiedReceiver(if (fraud) radarVerifiedReceiver else null)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error attaching verified receiver", e)
+                }
+                synchronized(eventQueue.lock) {
+                    if (!isInvalidated) {
+                        eventQueue.initialized()
+                        scheduleDrain()
+                    }
+                }
             } catch (e: Throwable) {
-                initializationInProgress = false
-                receiverAttachmentPending = false
-                if (activeReceiverOwner === receiverOwner) {
+                synchronized(eventQueue.lock) {
+                    eventQueue.abortInitialization()
+                    drainHandler.removeCallbacks(drainRunnable)
+                    drainScheduled = false
+                }
+                if (activeReceiverOwner === this) {
                     detachReceiversLocked()
                     activeReceiverOwner = null
                 }
                 throw e
             }
         }
-    }
-
-    private fun attachReceiversIfReadyLocked() {
-        if (
-            !receiverAttachmentPending ||
-            initializationInProgress ||
-            isInvalidated ||
-            !jsEventEmitterReady ||
-            activeReceiverOwner !== receiverOwner
-        ) {
-            return
-        }
-
-        Radar.setReceiver(radarReceiver)
-        Radar.setInAppMessageReceiver(radarInAppMessageReceiver)
-        try {
-            Radar.setVerifiedReceiver(if (receiverAttachmentFraud) radarVerifiedReceiver else null)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error attaching verified receiver", e)
-        }
-        receiverAttachmentPending = false
     }
 
     private fun detachReceiversLocked() {
@@ -282,14 +323,6 @@ class RadarModule(reactContext: ReactApplicationContext) :
             Radar.setInAppMessageReceiver(inactiveInAppMessageReceiver)
         } catch (e: Exception) {
             Log.e(TAG, "Error detaching in-app message receiver", e)
-        }
-    }
-
-    private fun emitIfActive(emit: () -> Unit) {
-        synchronized(receiverLock) {
-            if (!isInvalidated && jsEventEmitterReady && activeReceiverOwner === receiverOwner) {
-                emit()
-            }
         }
     }
 
@@ -627,7 +660,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         private const val TAG = "RadarModule"
         private val receiverLock = Any()
         @Volatile
-        private var activeReceiverOwner: Any? = null
+        private var activeReceiverOwner: RadarModule? = null
         private val inactiveInAppMessageReceiver = object : RadarInAppMessageReceiver {}
     }
 }

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -34,6 +34,7 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.CxxCallbackImpl
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -42,10 +43,17 @@ class RadarModule(reactContext: ReactApplicationContext) :
     NativeRadarSpec(reactContext), PermissionListener {
         @Volatile
         private var isInvalidated = false
+        @Volatile
+        private var jsEventEmitterReady = false
+
+    override fun setEventEmitterCallback(eventEmitterCallback: CxxCallbackImpl) {
+        super.setEventEmitterCallback(eventEmitterCallback)
+        jsEventEmitterReady = true
+    }
 
     private val radarReceiver = object : RadarReceiver() {
         override fun onEventsReceived(context: Context, events: Array<RadarEvent>, user: RadarUser?) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             val eventBlob = Arguments.createMap().apply {
                 var eventsArray = Arguments.createArray()
                 for (event in events) {
@@ -60,7 +68,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         }
 
         override fun onLocationUpdated(context: Context, location: Location, user: RadarUser) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             val eventBlob = Arguments.createMap().apply {
                 putString("location", Radar.jsonForLocation(location).toString())
                 putString("user", user.toJson().toString())
@@ -69,7 +77,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         }
 
         override fun onClientLocationUpdated(context: Context, location: Location, stopped: Boolean, source: Radar.RadarLocationSource) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             val eventBlob = Arguments.createMap().apply {
                 putString("location", Radar.jsonForLocation(location).toString())
                 putBoolean("stopped", stopped)
@@ -79,7 +87,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         }
 
         override fun onError(context: Context, status: Radar.RadarStatus) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             val eventBlob = Arguments.createMap().apply {
                 putString("status", status.toString())
             }
@@ -87,7 +95,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         }
 
         override fun onLog(context: Context, message: String) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             val eventBlob = Arguments.createMap().apply {
                 putString("message", message)
             }
@@ -97,7 +105,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
 
     private val radarInAppMessageReceiver = object : RadarInAppMessageReceiver {
         override fun onNewInAppMessage(message: RadarInAppMessage) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             try {
             val eventBlob = Arguments.createMap().apply {
                 putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
@@ -109,7 +117,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         }
 
         override fun onInAppMessageDismissed(message: RadarInAppMessage) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             try {
                 val eventBlob = Arguments.createMap().apply {
                     putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
@@ -121,7 +129,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
         }
 
         override fun onInAppMessageButtonClicked(message: RadarInAppMessage) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             try {
                 val eventBlob = Arguments.createMap().apply {
                     putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
@@ -135,7 +143,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
 
     private val radarVerifiedReceiver = object : RadarVerifiedReceiver() {
         override fun onTokenUpdated(context: Context, token: RadarVerifiedLocationToken) {
-            if (isInvalidated) return
+            if (isInvalidated || !jsEventEmitterReady) return
             val eventBlob = Arguments.createMap().apply {
                 putString("token", token.toJson().toString())
             }
@@ -153,6 +161,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
 
     override fun invalidate() {
         isInvalidated = true
+        jsEventEmitterReady = false
 
         // Detach from the process-level Radar singleton so this stale module
         // instance stops receiving callbacks after its JS runtime is gone.

--- a/android/src/newarch/java/com/radar/RadarModule.kt
+++ b/android/src/newarch/java/com/radar/RadarModule.kt
@@ -41,14 +41,22 @@ import org.json.JSONObject
 @ReactModule(name = RadarModule.NAME)
 class RadarModule(reactContext: ReactApplicationContext) :
     NativeRadarSpec(reactContext), PermissionListener {
-        @Volatile
-        private var isInvalidated = false
-        @Volatile
-        private var jsEventEmitterReady = false
+    private val receiverOwner = Any()
+
+    @Volatile
+    private var isInvalidated = false
+    @Volatile
+    private var jsEventEmitterReady = false
+    private var receiverAttachmentPending = false
+    private var receiverAttachmentFraud = false
+    private var initializationInProgress = false
 
     override fun setEventEmitterCallback(eventEmitterCallback: CxxCallbackImpl) {
         super.setEventEmitterCallback(eventEmitterCallback)
         jsEventEmitterReady = true
+        synchronized(receiverLock) {
+            attachReceiversIfReadyLocked()
+        }
     }
 
     private val radarReceiver = object : RadarReceiver() {
@@ -64,7 +72,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
                     putMap("user", RadarUtils.mapForJson(user.toJson()))
                 }
             }
-            emitEventsEmitter(eventBlob)
+            emitIfActive { emitEventsEmitter(eventBlob) }
         }
 
         override fun onLocationUpdated(context: Context, location: Location, user: RadarUser) {
@@ -73,7 +81,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
                 putString("location", Radar.jsonForLocation(location).toString())
                 putString("user", user.toJson().toString())
             }
-            emitLocationEmitter(eventBlob)
+            emitIfActive { emitLocationEmitter(eventBlob) }
         }
 
         override fun onClientLocationUpdated(context: Context, location: Location, stopped: Boolean, source: Radar.RadarLocationSource) {
@@ -83,7 +91,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
                 putBoolean("stopped", stopped)
                 putString("source", source.toString())
             }
-            emitClientLocationEmitter(eventBlob)
+            emitIfActive { emitClientLocationEmitter(eventBlob) }
         }
 
         override fun onError(context: Context, status: Radar.RadarStatus) {
@@ -91,7 +99,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
             val eventBlob = Arguments.createMap().apply {
                 putString("status", status.toString())
             }
-            emitErrorEmitter(eventBlob)
+            emitIfActive { emitErrorEmitter(eventBlob) }
         }
 
         override fun onLog(context: Context, message: String) {
@@ -99,7 +107,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
             val eventBlob = Arguments.createMap().apply {
                 putString("message", message)
             }
-            emitLogEmitter(eventBlob)
+            emitIfActive { emitLogEmitter(eventBlob) }
         }
     }
 
@@ -107,10 +115,10 @@ class RadarModule(reactContext: ReactApplicationContext) :
         override fun onNewInAppMessage(message: RadarInAppMessage) {
             if (isInvalidated || !jsEventEmitterReady) return
             try {
-            val eventBlob = Arguments.createMap().apply {
-                putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
-            }
-                emitNewInAppMessageEmitter(eventBlob)
+                val eventBlob = Arguments.createMap().apply {
+                    putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
+                }
+                emitIfActive { emitNewInAppMessageEmitter(eventBlob) }
             } catch (e: Exception) {
                 Log.e(TAG, "Exception", e)
             }
@@ -122,7 +130,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
                 val eventBlob = Arguments.createMap().apply {
                     putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
                 }
-                emitInAppMessageDismissedEmitter(eventBlob)
+                emitIfActive { emitInAppMessageDismissedEmitter(eventBlob) }
             } catch (e: Exception) {
                 Log.e(TAG, "Exception", e)
             }
@@ -134,7 +142,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
                 val eventBlob = Arguments.createMap().apply {
                     putMap("inAppMessage", RadarUtils.mapForJson(JSONObject(message.toJson())))
                 }
-                emitInAppMessageClickedEmitter(eventBlob)
+                emitIfActive { emitInAppMessageClickedEmitter(eventBlob) }
             } catch (e: Exception) {
                 Log.e(TAG, "Exception", e)
             }
@@ -147,7 +155,7 @@ class RadarModule(reactContext: ReactApplicationContext) :
             val eventBlob = Arguments.createMap().apply {
                 putString("token", token.toJson().toString())
             }
-            emitTokenEmitter(eventBlob)
+            emitIfActive { emitTokenEmitter(eventBlob) }
         }
     }
 
@@ -163,14 +171,13 @@ class RadarModule(reactContext: ReactApplicationContext) :
         isInvalidated = true
         jsEventEmitterReady = false
 
-        // Detach from the process-level Radar singleton so this stale module
-        // instance stops receiving callbacks after its JS runtime is gone.
-        Radar.setReceiver(null)
-
-        try {
-            Radar.setVerifiedReceiver(null)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error detaching verified receiver", e)
+        synchronized(receiverLock) {
+            receiverAttachmentPending = false
+            initializationInProgress = false
+            if (activeReceiverOwner === receiverOwner) {
+                detachReceiversLocked()
+                activeReceiverOwner = null
+            }
         }
 
         super.invalidate()
@@ -182,10 +189,18 @@ class RadarModule(reactContext: ReactApplicationContext) :
         editor.putString("x_platform_sdk_version", "4.36.0")
         editor.apply()
 
-        Radar.initialize(reactApplicationContext, publishableKey, radarReceiver, Radar.RadarLocationServicesProvider.GOOGLE, fraud, null, radarInAppMessageReceiver, currentActivity)
-        if (fraud) {
-            Radar.setVerifiedReceiver(radarVerifiedReceiver)
-        } 
+        initializeRadar(fraud) {
+            Radar.initialize(
+                reactApplicationContext,
+                publishableKey,
+                null,
+                Radar.RadarLocationServicesProvider.GOOGLE,
+                fraud,
+                null,
+                null,
+                currentActivity
+            )
+        }
     }
 
     override fun initializeWithAuthToken(authToken: String, fraud: Boolean, options: ReadableMap?): Unit {
@@ -196,15 +211,85 @@ class RadarModule(reactContext: ReactApplicationContext) :
         
         val initOptions = io.radar.sdk.RadarInitializeOptions.builder()
             .authToken(authToken)
-            .radarReceiver(radarReceiver)
             .locationProvider(Radar.RadarLocationServicesProvider.GOOGLE)
             .fraud(fraud)
-            .inAppMessageReceiver(radarInAppMessageReceiver)
             .apply { currentActivity?.let { activity(it) } }
             .build()
-        Radar.initialize(reactApplicationContext, initOptions)
-        if (fraud) {
-            Radar.setVerifiedReceiver(radarVerifiedReceiver)
+        initializeRadar(fraud) {
+            Radar.initialize(reactApplicationContext, initOptions)
+        }
+    }
+
+    private fun initializeRadar(fraud: Boolean, initialize: () -> Unit) {
+        synchronized(receiverLock) {
+            if (activeReceiverOwner != null) {
+                detachReceiversLocked()
+            }
+            activeReceiverOwner = receiverOwner
+            receiverAttachmentPending = true
+            receiverAttachmentFraud = fraud
+            initializationInProgress = true
+
+            try {
+                initialize()
+                initializationInProgress = false
+                attachReceiversIfReadyLocked()
+            } catch (e: Throwable) {
+                initializationInProgress = false
+                receiverAttachmentPending = false
+                if (activeReceiverOwner === receiverOwner) {
+                    detachReceiversLocked()
+                    activeReceiverOwner = null
+                }
+                throw e
+            }
+        }
+    }
+
+    private fun attachReceiversIfReadyLocked() {
+        if (
+            !receiverAttachmentPending ||
+            initializationInProgress ||
+            isInvalidated ||
+            !jsEventEmitterReady ||
+            activeReceiverOwner !== receiverOwner
+        ) {
+            return
+        }
+
+        Radar.setReceiver(radarReceiver)
+        Radar.setInAppMessageReceiver(radarInAppMessageReceiver)
+        try {
+            Radar.setVerifiedReceiver(if (receiverAttachmentFraud) radarVerifiedReceiver else null)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error attaching verified receiver", e)
+        }
+        receiverAttachmentPending = false
+    }
+
+    private fun detachReceiversLocked() {
+        // Radar keeps these receivers on a process-wide singleton, so only the
+        // current owner may detach them during handoff or teardown.
+        Radar.setReceiver(null)
+
+        try {
+            Radar.setVerifiedReceiver(null)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error detaching verified receiver", e)
+        }
+
+        try {
+            Radar.setInAppMessageReceiver(inactiveInAppMessageReceiver)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error detaching in-app message receiver", e)
+        }
+    }
+
+    private fun emitIfActive(emit: () -> Unit) {
+        synchronized(receiverLock) {
+            if (!isInvalidated && jsEventEmitterReady && activeReceiverOwner === receiverOwner) {
+                emit()
+            }
         }
     }
 
@@ -540,5 +625,9 @@ class RadarModule(reactContext: ReactApplicationContext) :
         const val NAME = "RNRadar"
         private const val PERMISSIONS_REQUEST_CODE = 1
         private const val TAG = "RadarModule"
+        private val receiverLock = Any()
+        @Volatile
+        private var activeReceiverOwner: Any? = null
+        private val inactiveInAppMessageReceiver = object : RadarInAppMessageReceiver {}
     }
 }

--- a/android/src/test/java/com/radar/EventPayloadTest.kt
+++ b/android/src/test/java/com/radar/EventPayloadTest.kt
@@ -1,0 +1,36 @@
+package com.radar
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+
+class EventPayloadTest {
+    @Test fun preservesLargeWholeDoublesAndExistingUnsupportedValueBehavior() {
+        val original = JSONObject()
+            .put("wholeDouble", 1000000000000.0)
+            .put("longSkippedByRadarUtils", 1000000000000L)
+            .put("float", 1.25f)
+            .put("nullSkippedByRadarUtils", JSONObject.NULL)
+            .put("array", JSONArray().put(1.25f).put(2).put(1000000000000.0))
+        val restored = EventPayload.restore(EventPayload.snapshot(original))
+        assertEquals(1000000000000.0, restored.get("wholeDouble"))
+        assertFalse(restored.has("longSkippedByRadarUtils"))
+        assertFalse(restored.has("nullSkippedByRadarUtils"))
+        assertEquals(1.25, restored.get("float"))
+        assertEquals(2, restored.getJSONArray("array").length())
+        assertEquals(1000000000000.0, restored.getJSONArray("array").get(1))
+    }
+
+    @Test fun snapshotsNestedObjectsAndKeepsStringPayloadsAsStrings() {
+        val child = JSONObject().put("message", "before")
+        val original = JSONObject().put("child", child).put("location", "{\"latitude\":1}")
+        val snapshot = EventPayload.snapshot(original)
+        child.put("message", "after")
+        val restored = EventPayload.restore(snapshot)
+        assertEquals("before", restored.getJSONObject("child").getString("message"))
+        assertEquals("{\"latitude\":1}", restored.get("location"))
+        restored.getJSONObject("child").put("message", "changed on emit")
+        assertEquals("before", EventPayload.restore(snapshot).getJSONObject("child").getString("message"))
+    }
+}

--- a/android/src/test/java/com/radar/StartupEventQueueTest.kt
+++ b/android/src/test/java/com/radar/StartupEventQueueTest.kt
@@ -1,0 +1,202 @@
+package com.radar
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+
+class StartupEventQueueTest {
+    @Test fun allNineTypesAreRetainedUntilTheirListenersRegister() {
+        val queue = StartupEventQueue()
+        val names = listOf(
+            "eventsEmitter", "locationEmitter", "clientLocationEmitter",
+            "errorEmitter", "logEmitter", "tokenEmitter", "newInAppMessageEmitter",
+            "inAppMessageDismissedEmitter", "inAppMessageClickedEmitter",
+        )
+        queue.listenerCount("logEmitter", 0)
+        names.forEach { queue.submit(it, "{\"name\":\"$it\"}") }
+        ready(queue)
+        queue.drain { fail("No listeners") }
+        val received = mutableListOf<String>()
+        names.reversed().forEach { name ->
+            queue.listenerCount(name, 1)
+            queue.drain { received.add(it.name) }
+        }
+        assertEquals(names.reversed(), received)
+    }
+
+    @Test fun productionLimitsBoundRetainedEntriesAndPayloadBytes() {
+        val queue = StartupEventQueue()
+        repeat(256) { assertFalse(queue.submit("a", "x")) }
+        assertTrue(queue.submit("a", "last"))
+        ready(queue)
+        var count = 0
+        queue.drain { count++ }
+        assertEquals(256, count)
+
+        val byteQueue = StartupEventQueue()
+        assertFalse(byteQueue.submit("a", "x".repeat(1024 * 1024)))
+        assertTrue(byteQueue.submit("a", "replacement"))
+        ready(byteQueue)
+        byteQueue.drain { assertEquals("replacement", it.payload) }
+    }
+
+    private fun ready(queue: StartupEventQueue) {
+        queue.claim()
+        queue.initialized()
+        queue.emitterReady()
+    }
+
+    @Test fun startupWaitsForBothReadinessOrdersAndOwnership() {
+        for (emitterFirst in listOf(true, false)) {
+            val queue = StartupEventQueue()
+            val received = mutableListOf<String>()
+            queue.submit("a", "constructor")
+            if (emitterFirst) queue.emitterReady() else queue.initialized()
+            queue.drain { fail("Not ready") }
+            if (emitterFirst) queue.initialized() else queue.emitterReady()
+            queue.drain { fail("Not the owner") }
+            queue.claim()
+            queue.drain { received.add(it.payload) }
+            assertEquals(listOf("constructor"), received)
+        }
+    }
+
+    @Test fun lateListenersDoNotBlockOtherTypesOrLetLiveEventsOvertake() {
+        val queue = StartupEventQueue()
+        queue.listenerCount("b", 1)
+        queue.submit("a", "a1")
+        queue.submit("b", "b1")
+        queue.submit("a", "a2")
+        ready(queue)
+        val received = mutableListOf<String>()
+        queue.drain { received.add(it.payload) }
+        assertEquals(listOf("b1"), received)
+        queue.submit("a", "unsubscribed live")
+        queue.listenerCount("a", 1)
+        queue.submit("a", "a3")
+        queue.drain { received.add(it.payload) }
+        assertEquals(listOf("b1", "a1", "a2", "a3"), received)
+        queue.listenerCount("a", 0)
+        queue.submit("a", "removed")
+        queue.listenerCount("a", 1)
+        queue.drain { fail("Live events without listeners must not accumulate") }
+    }
+
+    @Test fun capturesArrivalsDuringInitializationWithoutHoldingQueueLock() {
+        val queue = StartupEventQueue()
+        queue.claim()
+        queue.emitterReady()
+        queue.beginInitialization()
+        val callback = thread { queue.submit("a", "during init") }
+        callback.join(2000)
+        assertFalse(callback.isAlive)
+        queue.drain { fail("Initialization is incomplete") }
+        queue.initialized()
+        var count = 0
+        queue.drain { count++ }
+        assertEquals(1, count)
+    }
+
+    @Test fun concurrentArrivalsStayBehindBacklog() {
+        val queue = StartupEventQueue()
+        queue.submit("a", "first")
+        ready(queue)
+        val entered = CountDownLatch(1)
+        val submitted = CountDownLatch(1)
+        val received = mutableListOf<String>()
+        val callback = thread {
+            entered.await()
+            submitted.countDown()
+            queue.submit("a", "second")
+        }
+        queue.drain {
+            received.add(it.payload)
+            entered.countDown()
+            submitted.await()
+        }
+        callback.join(2000)
+        assertFalse(callback.isAlive)
+        queue.drain { received.add(it.payload) }
+        assertEquals(listOf("first", "second"), received)
+    }
+
+    @Test fun evictsOldestByCountAndUtf8BytesAndRejectsOversized() {
+        val queue = StartupEventQueue(maxEntries = 2, maxBytes = 5)
+        assertFalse(queue.submit("a", "1"))
+        assertFalse(queue.submit("b", "2"))
+        assertTrue(queue.submit("c", "3"))
+        assertTrue(queue.submit("d", "éé"))
+        assertTrue(queue.submit("e", "oversized"))
+        ready(queue)
+        val received = mutableListOf<String>()
+        queue.drain { received.add(it.payload) }
+        assertEquals(listOf("3", "éé"), received)
+    }
+
+    @Test fun serializedSnapshotsAreImmutable() {
+        val queue = StartupEventQueue()
+        val mutable = StringBuilder("before")
+        queue.submit("a", mutable.toString())
+        mutable.replace(0, mutable.length, "after")
+        ready(queue)
+        queue.drain { assertEquals("before", it.payload) }
+    }
+
+    @Test fun closeCancelsPendingAndFutureDeliveryEvenAfterReadiness() {
+        val queue = StartupEventQueue()
+        queue.submit("a", "pending")
+        queue.close()
+        ready(queue)
+        queue.submit("a", "stale")
+        queue.drain { fail("Closed queues cannot emit") }
+    }
+
+    @Test fun ownershipReplacementClosesOldQueueWithoutClosingReplacement() {
+        val old = StartupEventQueue()
+        old.submit("a", "old")
+        ready(old)
+        old.close()
+        val replacement = StartupEventQueue()
+        replacement.submit("a", "new")
+        ready(replacement)
+        old.close()
+        old.drain { fail("Old owner") }
+        replacement.drain { assertEquals("new", it.payload) }
+    }
+
+    @Test fun teardownWaitsForCurrentEmissionAndStopsNextEmission() {
+        val queue = StartupEventQueue()
+        queue.submit("a", "first")
+        queue.submit("a", "second")
+        ready(queue)
+        val received = mutableListOf<String>()
+        queue.drain {
+            received.add(it.payload)
+            queue.close()
+        }
+        assertEquals(listOf("first"), received)
+    }
+
+    @Test fun olderJavascriptWithoutNegotiationStillReceivesEvents() {
+        val queue = StartupEventQueue()
+        ready(queue)
+        queue.submit("a", "live")
+        var count = 0
+        queue.drain { count++ }
+        assertEquals(1, count)
+    }
+
+    @Test fun initializationFailureCancelsBacklogButAllowsRetry() {
+        val queue = StartupEventQueue()
+        queue.submit("a", "before failure")
+        queue.abortInitialization()
+        queue.submit("a", "after failure")
+        queue.beginInitialization()
+        queue.submit("a", "retry")
+        ready(queue)
+        val received = mutableListOf<String>()
+        queue.drain { received.add(it.payload) }
+        assertEquals(listOf("retry"), received)
+    }
+}

--- a/ios/RNRadar.mm
+++ b/ios/RNRadar.mm
@@ -76,6 +76,10 @@ RCT_EXPORT_MODULE()
     [super setEventEmitterCallback:eventEmitterCallbackWrapper];
     jsEventEmitterReady = YES;
 }
+
+- (void)_setEventListenerCount:(NSString *)eventName count:(NSInteger)count {
+    // Android needs this handshake; iOS keeps its existing event handling.
+}
 #endif
 
 - (void)onNewInAppMessage:(RadarInAppMessage *)inAppMessage {

--- a/src/NativeRadar.ts
+++ b/src/NativeRadar.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
-import type { EventEmitter } from "react-native/Libraries/Types/CodegenTypes";
+import type { EventEmitter, Int32 } from "react-native/Libraries/Types/CodegenTypes";
 
 export type LocationEmitter = {
   location: Object;
@@ -43,6 +43,7 @@ export type InAppMessageClickedEmitter = {
 };
 
 export interface Spec extends TurboModule {
+  _setEventListenerCount(eventName: string, count: Int32): void;
   initialize(publishableKey: string, fraud: boolean, options: Object | null): void;
   initializeWithAuthToken(authToken: string, fraud: boolean, options: Object | null): void;
   requestPermissions(background: boolean): Promise<string>;

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,68 @@
-it.todo('write a test');
+type RadarNativeMock = {
+  initialize: jest.Mock;
+  initializeWithAuthToken: jest.Mock;
+  locationEmitter?: jest.Mock;
+  newInAppMessageEmitter?: jest.Mock;
+};
+
+const loadRadar = (newArchitecture: boolean) => {
+  jest.resetModules();
+
+  const nativeModules =
+    require("react-native/Libraries/BatchedBridge/NativeModules").default;
+  const nativeRadar = nativeModules.RNRadar as RadarNativeMock;
+  const order: string[] = [];
+  const subscription = { remove: jest.fn() };
+
+  nativeRadar.initialize.mockImplementation(() => order.push("initialize"));
+  nativeRadar.initializeWithAuthToken.mockImplementation(() =>
+    order.push("initialize")
+  );
+
+  if (newArchitecture) {
+    nativeRadar.locationEmitter = jest.fn();
+    nativeRadar.newInAppMessageEmitter = jest.fn(() => {
+      order.push("listener");
+      return subscription;
+    });
+  } else {
+    nativeRadar.locationEmitter = undefined;
+    const NativeEventEmitter =
+      require("react-native/Libraries/EventEmitter/NativeEventEmitter").default;
+    NativeEventEmitter.mockImplementation(() => ({
+      addListener: jest.fn(() => {
+        order.push("listener");
+        return subscription;
+      }),
+      removeListeners: jest.fn(),
+      removeAllListeners: jest.fn(),
+    }));
+  }
+
+  const radar = require("../index.native").default;
+  return { nativeRadar, order, radar };
+};
+
+describe.each([
+  ["initialize", (radar: any) => radar.initialize("prj_test_pk")],
+  [
+    "initializeWithAuthToken",
+    (radar: any) => radar.initializeWithAuthToken("token"),
+  ],
+])("%s", (_name, initialize) => {
+  it("registers the New Architecture listener before native initialization", () => {
+    const { order, radar } = loadRadar(true);
+
+    initialize(radar);
+
+    expect(order).toEqual(["listener", "initialize"]);
+  });
+
+  it("preserves the Old Architecture listener ordering", () => {
+    const { order, radar } = loadRadar(false);
+
+    initialize(radar);
+
+    expect(order).toEqual(["initialize", "listener"]);
+  });
+});

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -3,16 +3,25 @@ type RadarNativeMock = {
   initializeWithAuthToken: jest.Mock;
   locationEmitter?: jest.Mock;
   newInAppMessageEmitter?: jest.Mock;
+  _setEventListenerCount?: jest.Mock;
 };
 
-const loadRadar = (newArchitecture: boolean) => {
+const loadRadar = (
+  newArchitecture: boolean,
+  platform = "android",
+  tracking = true
+) => {
   jest.resetModules();
+  require("react-native").Platform.OS = platform;
 
   const nativeModules =
     require("react-native/Libraries/BatchedBridge/NativeModules").default;
   const nativeRadar = nativeModules.RNRadar as RadarNativeMock;
   const order: string[] = [];
-  const subscription = { remove: jest.fn() };
+  const subscription = () => ({ remove: jest.fn(() => order.push("remove")) });
+  nativeRadar._setEventListenerCount = tracking
+    ? jest.fn((name, count) => order.push(name + ":" + count))
+    : undefined;
 
   nativeRadar.initialize.mockImplementation(() => order.push("initialize"));
   nativeRadar.initializeWithAuthToken.mockImplementation(() =>
@@ -20,10 +29,10 @@ const loadRadar = (newArchitecture: boolean) => {
   );
 
   if (newArchitecture) {
-    nativeRadar.locationEmitter = jest.fn();
+    nativeRadar.locationEmitter = jest.fn(subscription);
     nativeRadar.newInAppMessageEmitter = jest.fn(() => {
       order.push("listener");
-      return subscription;
+      return subscription();
     });
   } else {
     nativeRadar.locationEmitter = undefined;
@@ -32,15 +41,15 @@ const loadRadar = (newArchitecture: boolean) => {
     NativeEventEmitter.mockImplementation(() => ({
       addListener: jest.fn(() => {
         order.push("listener");
-        return subscription;
+        return subscription();
       }),
       removeListeners: jest.fn(),
       removeAllListeners: jest.fn(),
     }));
   }
 
-  const radar = require("../index.native").default;
-  return { nativeRadar, order, radar };
+  const { default: radar, addListener } = require("../index.native");
+  return { nativeRadar, order, radar, addListener };
 };
 
 describe.each([
@@ -55,7 +64,11 @@ describe.each([
 
     initialize(radar);
 
-    expect(order).toEqual(["listener", "initialize"]);
+    expect(order).toEqual([
+      "listener",
+      "newInAppMessageEmitter:1",
+      "initialize",
+    ]);
   });
 
   it("preserves the Old Architecture listener ordering", () => {
@@ -65,4 +78,66 @@ describe.each([
 
     expect(order).toEqual(["initialize", "listener"]);
   });
+
+  it("preserves iOS delivery without negotiating counts", () => {
+    const { order, radar, nativeRadar } = loadRadar(true, "ios");
+    initialize(radar);
+    expect(order).toEqual(["listener", "initialize"]);
+    expect(nativeRadar._setEventListenerCount).not.toHaveBeenCalled();
+  });
+
+  it("supports older native binaries without the handshake", () => {
+    const { order, radar } = loadRadar(true, "android", false);
+    initialize(radar);
+    expect(order).toEqual(["listener", "initialize"]);
+  });
+
+  it("replaces the default listener on repeated initialization", () => {
+    const { order, radar } = loadRadar(true);
+    initialize(radar);
+    initialize(radar);
+    expect(order).toEqual([
+      "listener",
+      "newInAppMessageEmitter:1",
+      "initialize",
+      "remove",
+      "newInAppMessageEmitter:0",
+      "listener",
+      "newInAppMessageEmitter:1",
+      "initialize",
+    ]);
+  });
+});
+
+it("counts subscriptions after installation and removes each only once", () => {
+  const { addListener, order, nativeRadar } = loadRadar(true);
+  const first = addListener("newInAppMessageEmitter", jest.fn());
+  const second = addListener("newInAppMessageEmitter", jest.fn());
+  first.remove();
+  first.remove();
+  second.remove();
+  expect(order).toEqual([
+    "listener",
+    "newInAppMessageEmitter:1",
+    "listener",
+    "newInAppMessageEmitter:2",
+    "remove",
+    "newInAppMessageEmitter:1",
+    "remove",
+    "newInAppMessageEmitter:0",
+  ]);
+  expect(nativeRadar.newInAppMessageEmitter).toHaveBeenCalledTimes(2);
+});
+
+it("reports listener replacement without accumulating old subscriptions", () => {
+  const { radar, nativeRadar } = loadRadar(true);
+  radar.onLocationUpdated(jest.fn());
+  radar.onLocationUpdated(jest.fn());
+  radar.onLocationUpdated(null);
+  expect(nativeRadar._setEventListenerCount?.mock.calls).toEqual([
+    ["locationEmitter", 1],
+    ["locationEmitter", 0],
+    ["locationEmitter", 1],
+    ["locationEmitter", 0],
+  ]);
 });

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -90,6 +90,7 @@ const compatEventEmitter =
   NativeRadar.locationEmitter == null
     ? new NativeEventEmitter(NativeModules.RNRadar)
     : null;
+const isNewArchitecture = compatEventEmitter == null;
 
 type Events =
   | "locationEmitter"
@@ -122,20 +123,40 @@ let newInAppMessageUpdateSubscription: EventSubscription | null = null;
 let inAppMessageDismissedUpdateSubscription: EventSubscription | null = null;
 let inAppMessageClickedUpdateSubscription: EventSubscription | null = null;
 
+const registerDefaultInAppMessageHandler = () => {
+  Radar.onNewInAppMessage((inAppMessage) => {
+    Radar.showInAppMessage(inAppMessage);
+  });
+};
+
 const Radar: RadarNativeInterface = {
-  initialize: (publishableKey: string, fraud?: boolean, options?: Object | null) => {
+  initialize: (
+    publishableKey: string,
+    fraud?: boolean,
+    options?: Object | null
+  ) => {
+    if (isNewArchitecture) {
+      registerDefaultInAppMessageHandler();
+    }
     NativeRadar.initialize(publishableKey, !!fraud, options || null);
-    Radar.onNewInAppMessage((inAppMessage) => {
-      Radar.showInAppMessage(inAppMessage);
-    });
+    if (!isNewArchitecture) {
+      registerDefaultInAppMessageHandler();
+    }
     return;
   },
 
-  initializeWithAuthToken: (authToken: string, fraud?: boolean, options?: Object | null) => {
+  initializeWithAuthToken: (
+    authToken: string,
+    fraud?: boolean,
+    options?: Object | null
+  ) => {
+    if (isNewArchitecture) {
+      registerDefaultInAppMessageHandler();
+    }
     NativeRadar.initializeWithAuthToken(authToken, !!fraud, options || null);
-    Radar.onNewInAppMessage((inAppMessage) => {
-      Radar.showInAppMessage(inAppMessage);
-    });
+    if (!isNewArchitecture) {
+      registerDefaultInAppMessageHandler();
+    }
     return;
   },
 

--- a/src/index.native.ts
+++ b/src/index.native.ts
@@ -91,6 +91,11 @@ const compatEventEmitter =
     ? new NativeEventEmitter(NativeModules.RNRadar)
     : null;
 const isNewArchitecture = compatEventEmitter == null;
+const tracksListeners =
+  isNewArchitecture &&
+  Platform.OS === "android" &&
+  typeof NativeRadar._setEventListenerCount === "function";
+const listenerCounts = new Map<string, number>();
 
 type Events =
   | "locationEmitter"
@@ -110,7 +115,25 @@ export function addListener<EventT extends Events>(
   if (compatEventEmitter != null) {
     return compatEventEmitter.addListener(event, handler);
   }
-  return NativeRadar[event](handler as any);
+  const subscription = NativeRadar[event](handler as any);
+  if (!tracksListeners) return subscription;
+
+  const updateCount = (change: number) => {
+    const count = (listenerCounts.get(event) ?? 0) + change;
+    listenerCounts.set(event, count);
+    NativeRadar._setEventListenerCount(event, count);
+  };
+  // Native can replay startup events only after the JS subscription exists.
+  updateCount(1);
+  let removed = false;
+  const remove = subscription.remove.bind(subscription);
+  subscription.remove = () => {
+    if (removed) return;
+    removed = true;
+    remove();
+    updateCount(-1);
+  };
+  return subscription;
 }
 
 let locationUpdateSubscription: EventSubscription | null = null;


### PR DESCRIPTION
## Summary

Fix Android New Architecture TurboModule event emitter lifecycle races during startup and React Native reloads.

Replace deferred receiver attachment with an instance-local startup queue for all nine callback types. Pass the regular and in-app receivers into both SDK initialization methods so callbacks during initialization are captured. SDK initialization remains inline; receivers and their ownership are serialized separately from the queue lock.

- Drain only after SDK initialization and emitter setup complete, the module owns the receivers, and the matching JavaScript listener is installed. Keep each event type's startup backlog for late listeners, without blocking other types or letting live events overtake their own backlog.
- After startup, do not accumulate new events for types without subscribers. Retain at most **256 entries / 1 MiB of serialized payloads per instance**; evict oldest entries or reject an oversized entry, with rate-limited Android warnings.
- Clear pending events and cancel drains on teardown, ownership replacement, or initialization failure. There is no persistence or replay across reloads. Teardown and overflow are explicit exceptions to startup delivery.
- Store immutable serialized payloads and create fresh React Native maps for delivery, preserving existing payload conversion behavior.
- Add the internal `_setEventListenerCount` handshake with idempotent subscription removal on Android New Architecture. Older native binaries are feature-detected; older JavaScript bundles that never negotiate tracking retain readiness-guarded delivery.

Receiver ownership is tracked across module instances so teardown of an invalidated module cannot detach receivers installed for a newer module. Teardown clears regular and verified receivers and installs a no-op in-app receiver because the SDK setter requires a non-null receiver. Rebind the in-app receiver on every initialization.

Keep the default in-app listener before native initialization under New Architecture and preserve Old Architecture ordering. Event names, payload shapes, public Radar APIs, and iOS event handling remain unchanged. iOS implements only the approved no-op for the shared internal method.

Related: [issue #428](https://github.com/radarlabs/react-native-radar/issues/428), `FENCE-3006`.

## Reproduction

Inject a marked callback through an actual receiver method, such as `radarReceiver.onLog(...)`, after receiver construction but before `setEventEmitterCallback`. Initialize the SDK, then install the matching JavaScript listener after a delay. The queued implementation must remain running and replay that callback after subscription.

Directly calling a generated method such as `emitClientLocationEmitter` bypasses the receiver queue and cannot validate this fix. The previous direct-emitter smoke-test claim is withdrawn.

## Test Plan

1. Launch the Android example with New Architecture enabled and a temporary marked receiver callback during construction or SDK initialization. Confirm the native injection marker appears and the app remains running.
2. Register the matching JavaScript listener after initialization. Confirm the startup callback arrives once; trigger another callback and confirm normal delivery in order.
3. Leave one event type unsubscribed while subscribing to another. Confirm the subscribed type is delivered immediately; subscribe to the first type and confirm its startup backlog arrives in order.
4. Reload the React Native instance, invoke the old receiver, and confirm no stale JavaScript callback or crash occurs. Invoke teardown on the old module again and confirm the new instance still receives callbacks.
5. Trigger an in-app message after initializing the replacement instance. Confirm the replacement receives it.
6. Queue a callback, tear down its instance before the scheduled drain runs, and confirm it is not delivered. Restore the temporary callback injections afterward.

## Validation

- `npm run typecheck` — passed.
- `npm test -- --runInBand` — passed: 2 suites, 61 tests.
- `:react-native-radar:testDebugUnitTest` — passed: 15 JVM tests covering readiness order, startup capture, late listeners, ordering, concurrent arrivals, limits, immutable payloads, cancellation, ownership replacement, initialization retry, and older-JavaScript fallback.
- `cd example/android && ./gradlew assembleDebug --no-daemon` — passed on restored, non-harness sources.
- iOS code generation and focused `Radar` / generated bridge compilation — passed for simulator with the generated-header directory explicitly added to the search path. The full example build remains blocked by missing existing ExpoFileSystem headers, including `EXTaskHandlersManager.h`.
- Emulator receiver harness — native and JavaScript markers confirmed constructor/initialization callback replay after a late subscription, live delivery, an actual React Native reload, rejected stale callbacks, and regular/in-app receiver ownership and delivery after a second teardown of the old module.
- Emulator cancellation harness — confirmed a receiver callback queued immediately before invalidation was canceled, a subsequent stale callback was rejected, and JavaScript remained running.
- The offline harness imported the native wrapper directly and disabled release minification/resource shrinking to bypass the example's unrelated MapLibre/optional Firebase build problems. Temporary source changes were restored.
- `git diff --check` — passed.
